### PR TITLE
More on renaming

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -38,6 +38,8 @@ object ToolBase {
 
     const val lib = "$group:spine-tool-base:$version"
     const val pluginBase = "$group:spine-plugin-base:$version"
+    const val gradleRootPlugin = "$group:spine-gradle-root-plugin:$version"
+    const val gradlePluginApi = "$group:spine-gradle-plugin-api:$version"
     const val pluginTestlib = "$group:spine-plugin-testlib:$version"
 
     const val intellijPlatformJava = "$group:intellij-platform-java:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -34,7 +34,7 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object ToolBase {
     const val group = Spine.toolsGroup
-    const val version = "2.0.0-SNAPSHOT.333"
+    const val version = "2.0.0-SNAPSHOT.334"
 
     const val lib = "$group:spine-tool-base:$version"
     const val pluginBase = "$group:spine-plugin-base:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -34,7 +34,7 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object ToolBase {
     const val group = Spine.toolsGroup
-    const val version = "2.0.0-SNAPSHOT.334"
+    const val version = "2.0.0-SNAPSHOT.335"
 
     const val lib = "$group:spine-tool-base:$version"
     const val pluginBase = "$group:spine-plugin-base:$version"

--- a/dependencies.md
+++ b/dependencies.md
@@ -1046,7 +1046,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1836,7 +1836,7 @@ This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2887,7 +2887,7 @@ This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3962,7 +3962,7 @@ This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4948,7 +4948,7 @@ This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5982,7 +5982,7 @@ This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7033,7 +7033,7 @@ This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8076,7 +8076,7 @@ This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8884,7 +8884,7 @@ This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9931,7 +9931,7 @@ This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11080,4 +11080,4 @@ This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.compiler:api:2.0.0-SNAPSHOT.007`
+# Dependencies of `io.spine.compiler:api:2.0.0-SNAPSHOT.008`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -1046,12 +1046,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue May 27 20:07:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.compiler:api-tests:2.0.0-SNAPSHOT.007`
+# Dependencies of `io.spine.compiler:api-tests:2.0.0-SNAPSHOT.008`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1836,12 +1836,12 @@ This report was generated on **Tue May 27 20:07:11 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue May 27 20:07:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.compiler:backend:2.0.0-SNAPSHOT.007`
+# Dependencies of `io.spine.compiler:backend:2.0.0-SNAPSHOT.008`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -2887,12 +2887,12 @@ This report was generated on **Tue May 27 20:07:11 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue May 27 20:07:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.compiler:cli:2.0.0-SNAPSHOT.007`
+# Dependencies of `io.spine.compiler:cli:2.0.0-SNAPSHOT.008`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -3962,12 +3962,12 @@ This report was generated on **Tue May 27 20:07:11 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue May 27 20:07:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.compiler:gradle-api:2.0.0-SNAPSHOT.007`
+# Dependencies of `io.spine.compiler:gradle-api:2.0.0-SNAPSHOT.008`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -4948,12 +4948,12 @@ This report was generated on **Tue May 27 20:07:11 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue May 27 20:07:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.compiler:gradle-plugin:2.0.0-SNAPSHOT.007`
+# Dependencies of `io.spine.compiler:gradle-plugin:2.0.0-SNAPSHOT.008`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -5982,12 +5982,12 @@ This report was generated on **Tue May 27 20:07:11 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue May 27 20:07:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.compiler:jvm:2.0.0-SNAPSHOT.007`
+# Dependencies of `io.spine.compiler:jvm:2.0.0-SNAPSHOT.008`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -7033,12 +7033,12 @@ This report was generated on **Tue May 27 20:07:11 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue May 27 20:07:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.compiler:params:2.0.0-SNAPSHOT.007`
+# Dependencies of `io.spine.compiler:params:2.0.0-SNAPSHOT.008`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -8076,12 +8076,12 @@ This report was generated on **Tue May 27 20:07:11 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue May 27 20:07:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.compiler:protoc-plugin:2.0.0-SNAPSHOT.007`
+# Dependencies of `io.spine.compiler:protoc-plugin:2.0.0-SNAPSHOT.008`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -8884,12 +8884,12 @@ This report was generated on **Tue May 27 20:07:11 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue May 27 20:07:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.compiler:test-env:2.0.0-SNAPSHOT.007`
+# Dependencies of `io.spine.compiler:test-env:2.0.0-SNAPSHOT.008`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -9931,12 +9931,12 @@ This report was generated on **Tue May 27 20:07:11 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue May 27 20:07:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.compiler:testlib:2.0.0-SNAPSHOT.007`
+# Dependencies of `io.spine.compiler:testlib:2.0.0-SNAPSHOT.008`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -11080,4 +11080,4 @@ This report was generated on **Tue May 27 20:07:11 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue May 27 20:07:11 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1046,7 +1046,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1836,7 +1836,7 @@ This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2887,7 +2887,7 @@ This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3962,7 +3962,7 @@ This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4948,7 +4948,7 @@ This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5982,7 +5982,7 @@ This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7033,7 +7033,7 @@ This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8076,7 +8076,7 @@ This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8884,7 +8884,7 @@ This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9931,7 +9931,7 @@ This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11080,4 +11080,4 @@ This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 29 20:04:09 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri May 30 19:46:38 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1046,7 +1046,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 03 18:11:05 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1836,7 +1836,7 @@ This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 03 18:11:05 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2887,7 +2887,7 @@ This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 03 18:11:05 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3962,7 +3962,7 @@ This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 03 18:11:05 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4948,7 +4948,7 @@ This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 03 18:11:05 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5982,7 +5982,7 @@ This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 03 18:11:05 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -7033,7 +7033,7 @@ This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 03 18:11:05 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8076,7 +8076,7 @@ This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 03 18:11:05 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -8884,7 +8884,7 @@ This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 03 18:11:05 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -9931,7 +9931,7 @@ This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 03 18:11:05 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -11080,4 +11080,4 @@ This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jun 03 17:27:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jun 03 18:11:05 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/gradle-api/build.gradle.kts
+++ b/gradle-api/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     compileOnly(gradleApi())
 
     implementation(ToolBase.pluginBase)
+    implementation(ToolBase.gradlePluginApi)
     implementation(project(":api"))
     implementation(project(":params"))
 

--- a/gradle-api/src/main/kotlin/io/spine/compiler/gradle/api/CompilerSettings.kt
+++ b/gradle-api/src/main/kotlin/io/spine/compiler/gradle/api/CompilerSettings.kt
@@ -29,13 +29,13 @@ package io.spine.compiler.gradle.api
 import org.gradle.api.file.DirectoryProperty
 
 /**
- * Configures the code generation process performed by ProtoData.
+ * Configures the code generation process performed by the Compiler.
  */
-public interface CodegenSettings {
+public interface CompilerSettings {
 
     /**
-     * Passes given names of Java classes to ProtoData as
-     * the `io.spine.compiler.plugin.Plugin` classes.
+     * Passes given names of Java classes to the Compiler as classes
+     * extending the `io.spine.compiler.plugin.Plugin` class.
      */
     public fun plugins(vararg classNames: String)
 

--- a/gradle-api/src/main/kotlin/io/spine/compiler/gradle/api/Names.kt
+++ b/gradle-api/src/main/kotlin/io/spine/compiler/gradle/api/Names.kt
@@ -27,7 +27,7 @@
 package io.spine.compiler.gradle.api
 
 /**
- * The name of various objects in ProtoData Gradle API.
+ * The name of various objects in Spine Compiler Gradle API.
  */
 public object Names {
 

--- a/gradle-api/src/main/kotlin/io/spine/compiler/gradle/api/ProjectExts.kt
+++ b/gradle-api/src/main/kotlin/io/spine/compiler/gradle/api/ProjectExts.kt
@@ -33,24 +33,26 @@ import java.nio.file.Path
 import org.gradle.api.file.Directory
 import org.gradle.api.tasks.SourceSet
 
+//TODO:2025-05-29:alexander.yevsyukov: Nest it under the working directory of the `RootPlugin`.
 /**
  * Obtains the directory where ProtoData stores its temporary files.
  */
 public val Project.compilerWorkingDir: Directory
     get() = layout.buildDirectory.dir(PROTODATA_WORKING_DIR).get()
 
+//TODO:2025-05-29:alexander.yevsyukov: Nest it under the root extension.
 /**
- * Obtains the instance of [CodegenSettings] extension of this project.
+ * Obtains the instance of [CompilerSettings] extension of this project.
  */
-public val Project.codegenSettings: CodegenSettings
-    get() = extensions.findByType(CodegenSettings::class.java)!!
+public val Project.compilerSettings: CompilerSettings
+    get() = extensions.findByType(CompilerSettings::class.java)!!
 
 /**
  * Obtains the path of the directory with the generated code as configured by
- * the [CodegenSettings.outputBaseDir] property of the ProtoData extension of this Gradle project.
+ * the [CompilerSettings.outputBaseDir] property of the ProtoData extension of this Gradle project.
  */
 public val Project.generatedDir: Path
-    get() = codegenSettings.outputBaseDir.get().asFile.toPath()
+    get() = compilerSettings.outputBaseDir.get().asFile.toPath()
 
 /**
  * Obtains the `generated` directory for the given [sourceSet] and a language.

--- a/gradle-api/src/main/kotlin/io/spine/compiler/gradle/api/ProjectExts.kt
+++ b/gradle-api/src/main/kotlin/io/spine/compiler/gradle/api/ProjectExts.kt
@@ -26,14 +26,14 @@
 
 package io.spine.compiler.gradle.api
 
-import org.gradle.api.Project
 import io.spine.compiler.params.Directories.COMPILER_WORKING_DIR
-import io.spine.tools.gradle.root.rootExtension
+import io.spine.tools.gradle.lib.spineExtension
+import io.spine.tools.gradle.root.rootWorkingDir
 import java.io.File
 import java.nio.file.Path
+import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.tasks.SourceSet
-import io.spine.tools.gradle.root.rootWorkingDir
 
 /**
  * Obtains the directory where ProtoData stores its temporary files.
@@ -45,16 +45,7 @@ public val Project.compilerWorkingDir: Directory
  * Obtains the instance of [CompilerSettings] extension of this project.
  */
 public val Project.compilerSettings: CompilerSettings
-    get() {
-        // Compatibility mode for the migration phase.
-        val type = CompilerSettings::class.java
-        val underProject = extensions.findByType(type)
-        underProject?.let { return it }
-
-        // The new DSL: `spine { compiler { ... } }`
-        val underRootExt = rootExtension.extensions.findByType(type)
-        return underRootExt!!
-    }
+    get() = spineExtension<CompilerSettings>()
 
 /**
  * Obtains the path of the directory with the generated code as configured by

--- a/gradle-api/src/main/kotlin/io/spine/compiler/gradle/api/ProjectExts.kt
+++ b/gradle-api/src/main/kotlin/io/spine/compiler/gradle/api/ProjectExts.kt
@@ -27,25 +27,34 @@
 package io.spine.compiler.gradle.api
 
 import org.gradle.api.Project
-import io.spine.compiler.params.Directories.PROTODATA_WORKING_DIR
+import io.spine.compiler.params.Directories.COMPILER_WORKING_DIR
+import io.spine.tools.gradle.root.rootExtension
 import java.io.File
 import java.nio.file.Path
 import org.gradle.api.file.Directory
 import org.gradle.api.tasks.SourceSet
+import io.spine.tools.gradle.root.rootWorkingDir
 
-//TODO:2025-05-29:alexander.yevsyukov: Nest it under the working directory of the `RootPlugin`.
 /**
  * Obtains the directory where ProtoData stores its temporary files.
  */
 public val Project.compilerWorkingDir: Directory
-    get() = layout.buildDirectory.dir(PROTODATA_WORKING_DIR).get()
+    get() = rootWorkingDir.dir(COMPILER_WORKING_DIR)
 
-//TODO:2025-05-29:alexander.yevsyukov: Nest it under the root extension.
 /**
  * Obtains the instance of [CompilerSettings] extension of this project.
  */
 public val Project.compilerSettings: CompilerSettings
-    get() = extensions.findByType(CompilerSettings::class.java)!!
+    get() {
+        // Compatibility mode for the migration phase.
+        val type = CompilerSettings::class.java
+        val underProject = extensions.findByType(type)
+        underProject?.let { return it }
+
+        // The new DSL: `spine { compiler { ... } }`
+        val underRootExt = rootExtension.extensions.findByType(type)
+        return underRootExt!!
+    }
 
 /**
  * Obtains the path of the directory with the generated code as configured by

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -72,12 +72,13 @@ testing {
 }
 
 dependencies {
-    api(project(":gradle-api"))
-
     compileOnly(gradleApi())
     compileOnly(gradleKotlinDsl())
     compileOnly(Protobuf.GradlePlugin.lib)
     compileOnly(Kotlin.GradlePlugin.api)
+
+    api(project(":gradle-api"))
+    api(ToolBase.gradlePluginApi)
 
     implementation(project(":api"))
     implementation(project(":params"))
@@ -89,6 +90,7 @@ dependencies {
  * Make functional tests depend on publishing all the submodules to Maven Local so that
  * the Gradle plugin can get all the dependencies when it's applied to the test projects.
  */
+@Suppress("unused")
 val functionalTest: Task by tasks.getting {
     val task = this
     productionModules.forEach { subproject ->
@@ -108,6 +110,7 @@ val publishPlugins: Task by tasks.getting {
     enabled = !isSnapshot
 }
 
+@Suppress("unused")
 val publish: Task by tasks.getting {
     if (!isSnapshot) {
         dependsOn(publishPlugins)

--- a/gradle-plugin/src/functionalTest/resources/android-library/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/android-library/build.gradle.kts
@@ -34,7 +34,7 @@ buildscript {
 plugins {
     id("com.android.library") version "7.3.0" // Protobuf needs it to run.
     id("com.google.protobuf")
-    id("@PROTODATA_PLUGIN_ID@") version "@PROTODATA_VERSION@"
+    id("@COMPILER_PLUGIN_ID@") version "@COMPILER_VERSION@"
 }
 
 repositories {

--- a/gradle-plugin/src/functionalTest/resources/android-library/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/android-library/build.gradle.kts
@@ -42,11 +42,13 @@ repositories {
     standardToSpineSdk()
 }
 
-compiler {
-    plugins(
-        "io.spine.compiler.test.UnderscorePrefixRendererPlugin",
-        "io.spine.compiler.test.TestPlugin"
-    )
+spine {
+    compiler {
+        plugins(
+            "io.spine.compiler.test.UnderscorePrefixRendererPlugin",
+            "io.spine.compiler.test.TestPlugin"
+        )
+    }
 }
 
 dependencies {

--- a/gradle-plugin/src/functionalTest/resources/copy-grpc/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/copy-grpc/build.gradle.kts
@@ -37,7 +37,7 @@ plugins {
     java
     kotlin("jvm")
     id("com.google.protobuf")
-    id("@PROTODATA_PLUGIN_ID@") version "@PROTODATA_VERSION@"
+    id("@COMPILER_PLUGIN_ID@") version "@COMPILER_VERSION@"
 }
 
 repositories {

--- a/gradle-plugin/src/functionalTest/resources/empty-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/empty-test/build.gradle.kts
@@ -53,9 +53,11 @@ protobuf {
     }
 }
 
-compiler {
-    plugins(
-        "io.spine.compiler.test.UnderscorePrefixRendererPlugin",
-        "io.spine.compiler.test.TestPlugin"
-    )
+spine {
+    compiler {
+        plugins(
+            "io.spine.compiler.test.UnderscorePrefixRendererPlugin",
+            "io.spine.compiler.test.TestPlugin"
+        )
+    }
 }

--- a/gradle-plugin/src/functionalTest/resources/empty-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/empty-test/build.gradle.kts
@@ -35,7 +35,7 @@ plugins {
     java
     kotlin("jvm")
     id("com.google.protobuf")
-    id("@PROTODATA_PLUGIN_ID@") version "@PROTODATA_VERSION@"
+    id("@COMPILER_PLUGIN_ID@") version "@COMPILER_VERSION@"
 }
 
 repositories {

--- a/gradle-plugin/src/functionalTest/resources/java-kotlin-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/java-kotlin-test/build.gradle.kts
@@ -44,11 +44,13 @@ repositories {
     standardToSpineSdk()
 }
 
-compiler {
-    plugins(
-        "io.spine.compiler.test.NoOpRendererPlugin",
-        "io.spine.compiler.test.TestPlugin"
-    )
+spine {
+    compiler {
+        plugins(
+            "io.spine.compiler.test.NoOpRendererPlugin",
+            "io.spine.compiler.test.TestPlugin"
+        )
+    }
 }
 
 dependencies {

--- a/gradle-plugin/src/functionalTest/resources/java-kotlin-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/java-kotlin-test/build.gradle.kts
@@ -36,7 +36,7 @@ plugins {
     java
     kotlin("jvm")
     id("com.google.protobuf")
-    id("@PROTODATA_PLUGIN_ID@") version "@PROTODATA_VERSION@"
+    id("@COMPILER_PLUGIN_ID@") version "@COMPILER_VERSION@"
 }
 
 repositories {

--- a/gradle-plugin/src/functionalTest/resources/java-library-kotlin-jvm/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/java-library-kotlin-jvm/build.gradle.kts
@@ -44,11 +44,13 @@ repositories {
     standardToSpineSdk()
 }
 
-compiler {
-    plugins(
-        "io.spine.compiler.test.NoOpRendererPlugin",
-        "io.spine.compiler.test.TestPlugin"
-    )
+spine {
+    compiler {
+        plugins(
+            "io.spine.compiler.test.NoOpRendererPlugin",
+            "io.spine.compiler.test.TestPlugin"
+        )
+    }
 }
 
 dependencies {

--- a/gradle-plugin/src/functionalTest/resources/java-library-kotlin-jvm/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/java-library-kotlin-jvm/build.gradle.kts
@@ -36,7 +36,7 @@ plugins {
     `java-library`
     kotlin("jvm")
     id("com.google.protobuf")
-    id("@PROTODATA_PLUGIN_ID@") version "@PROTODATA_VERSION@"
+    id("@COMPILER_PLUGIN_ID@") version "@COMPILER_VERSION@"
 }
 
 repositories {

--- a/gradle-plugin/src/functionalTest/resources/kotlin-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/kotlin-test/build.gradle.kts
@@ -35,7 +35,7 @@ buildscript {
 plugins {
     kotlin("jvm")
     id("com.google.protobuf")
-    id("@PROTODATA_PLUGIN_ID@") version "@PROTODATA_VERSION@"
+    id("@COMPILER_PLUGIN_ID@") version "@COMPILER_VERSION@"
 }
 
 repositories {

--- a/gradle-plugin/src/functionalTest/resources/kotlin-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/kotlin-test/build.gradle.kts
@@ -43,11 +43,13 @@ repositories {
     standardToSpineSdk()
 }
 
-compiler {
-    plugins(
-        "io.spine.compiler.test.NoOpRendererPlugin",
-        "io.spine.compiler.test.TestPlugin"
-    )
+spine {
+    compiler {
+        plugins(
+            "io.spine.compiler.test.NoOpRendererPlugin",
+            "io.spine.compiler.test.TestPlugin"
+        )
+    }
 }
 
 dependencies {

--- a/gradle-plugin/src/functionalTest/resources/launch-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/launch-test/build.gradle.kts
@@ -53,9 +53,11 @@ protobuf {
     }
 }
 
-compiler {
-    plugins(
-        "io.spine.compiler.test.UnderscorePrefixRendererPlugin",
-        "io.spine.compiler.test.TestPlugin"
-    )
+spine {
+    compiler {
+        plugins(
+            "io.spine.compiler.test.UnderscorePrefixRendererPlugin",
+            "io.spine.compiler.test.TestPlugin"
+        )
+    }
 }

--- a/gradle-plugin/src/functionalTest/resources/launch-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/launch-test/build.gradle.kts
@@ -35,7 +35,7 @@ plugins {
     java
     kotlin("jvm")
     id("com.google.protobuf")
-    id("@PROTODATA_PLUGIN_ID@") version "@PROTODATA_VERSION@"
+    id("@COMPILER_PLUGIN_ID@") version "@COMPILER_VERSION@"
 }
 
 repositories {

--- a/gradle-plugin/src/functionalTest/resources/with-functional-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/with-functional-test/build.gradle.kts
@@ -45,11 +45,13 @@ repositories {
     standardToSpineSdk()
 }
 
-compiler {
-    plugins(
-        "io.spine.compiler.test.NoOpRendererPlugin",
-        "io.spine.compiler.test.TestPlugin"
-    )
+spine {
+    compiler {
+        plugins(
+            "io.spine.compiler.test.NoOpRendererPlugin",
+            "io.spine.compiler.test.TestPlugin"
+        )
+    }
 }
 
 dependencies {

--- a/gradle-plugin/src/functionalTest/resources/with-functional-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/with-functional-test/build.gradle.kts
@@ -37,7 +37,7 @@ plugins {
     java
     kotlin("jvm")
     id("com.google.protobuf")
-    id("@PROTODATA_PLUGIN_ID@") version "@PROTODATA_VERSION@"
+    id("@COMPILER_PLUGIN_ID@") version "@COMPILER_VERSION@"
 }
 
 repositories {

--- a/gradle-plugin/src/main/kotlin/io/spine/compiler/gradle/plugin/Extension.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/compiler/gradle/plugin/Extension.kt
@@ -28,11 +28,14 @@ package io.spine.compiler.gradle.plugin
 
 import com.google.common.annotations.VisibleForTesting
 import io.spine.compiler.gradle.api.CompilerSettings
+import io.spine.compiler.gradle.api.Names.EXTENSION_NAME
 import io.spine.tools.fs.DirectoryName.generated
+import io.spine.tools.gradle.DslSpec
 import io.spine.tools.gradle.protobuf.generatedSourceProtoDir
 import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.SourceSet
@@ -143,5 +146,25 @@ public class Extension(private val project: Project): CompilerSettings {
             "js",
             "dart",
         )
+    }
+}
+
+/**
+ * Overrides [DslSpec] for customizing creation of the [Extension].
+ */
+internal class CompilerDslSpec :
+    DslSpec<CompilerSettings>(EXTENSION_NAME, CompilerSettings::class) {
+
+    /**
+     * The function for obtaining a project to which the [Plugin] is applied.
+     *
+     * This property is injected at the [Plugin] constructor.
+     */
+    internal lateinit var project: () -> Project
+
+    override fun createIn(container: ExtensionContainer): CompilerSettings {
+        val extension = Extension(project())
+        container.add(extensionClass.java, name, extension)
+        return extension
     }
 }

--- a/gradle-plugin/src/main/kotlin/io/spine/compiler/gradle/plugin/Extension.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/compiler/gradle/plugin/Extension.kt
@@ -27,7 +27,7 @@
 package io.spine.compiler.gradle.plugin
 
 import com.google.common.annotations.VisibleForTesting
-import io.spine.compiler.gradle.api.CodegenSettings
+import io.spine.compiler.gradle.api.CompilerSettings
 import io.spine.tools.fs.DirectoryName.generated
 import io.spine.tools.gradle.protobuf.generatedSourceProtoDir
 import org.gradle.api.Project
@@ -41,7 +41,7 @@ import org.gradle.kotlin.dsl.listProperty
 /**
  * The `compiler { }` Gradle project extension.
  */
-public class Extension(private val project: Project): CodegenSettings {
+public class Extension(private val project: Project): CompilerSettings {
 
     private val factory = project.objects
 

--- a/gradle-plugin/src/main/kotlin/io/spine/compiler/gradle/plugin/LaunchSpineCompiler.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/compiler/gradle/plugin/LaunchSpineCompiler.kt
@@ -172,7 +172,7 @@ public abstract class LaunchSpineCompiler : JavaExec() {
 internal fun LaunchSpineCompiler.applyDefaults(sourceSet: SourceSet) {
     sourceSetName.set(sourceSet.name)
     val project = project
-    val ext = project.extension
+    val ext = project.compilerSettings
     plugins = ext.plugins
     compilerConfiguration = project.compilerRawArtifact
     userClasspathConfiguration = project.userClasspath

--- a/gradle-plugin/src/main/kotlin/io/spine/compiler/gradle/plugin/Plugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/compiler/gradle/plugin/Plugin.kt
@@ -36,7 +36,7 @@ import com.google.protobuf.gradle.GenerateProtoTask
 import io.spine.code.proto.DescriptorReference
 import io.spine.compiler.gradle.api.Artifacts
 import io.spine.compiler.gradle.api.SpineCompilerCleanTask
-import io.spine.compiler.gradle.api.CodegenSettings
+import io.spine.compiler.gradle.api.CompilerSettings
 import io.spine.compiler.gradle.api.CompilerTask
 import io.spine.compiler.gradle.api.Names.COMPILER_RAW_ARTIFACT
 import io.spine.compiler.gradle.api.Names.EXTENSION_NAME
@@ -134,18 +134,18 @@ public class Plugin : GradlePlugin<Project> {
  * Or, if the extension is not yet added, creates it and returns.
  */
 internal val Project.extension: Extension
-    get() = extensions.findByType(CodegenSettings::class)?.run { this as Extension }
+    get() = extensions.findByType(CompilerSettings::class)?.run { this as Extension }
         ?: createExtension()
 
 /**
  * Creates [Extension] associated with [Plugin] in this project.
  *
- * The extension is exposed by the type of [CodegenSettings] it implements to hide
+ * The extension is exposed by the type of [CompilerSettings] it implements to hide
  * the implementation details from the end-user projects.
  */
 private fun Project.createExtension(): Extension {
     val extension = Extension(this)
-    extensions.add(CodegenSettings::class.java, EXTENSION_NAME, extension)
+    extensions.add(CompilerSettings::class.java, EXTENSION_NAME, extension)
     return extension
 }
 

--- a/gradle-plugin/src/main/kotlin/io/spine/compiler/gradle/plugin/Plugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/compiler/gradle/plugin/Plugin.kt
@@ -35,15 +35,14 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue
 import com.google.protobuf.gradle.GenerateProtoTask
 import io.spine.code.proto.DescriptorReference
 import io.spine.compiler.gradle.api.Artifacts
-import io.spine.compiler.gradle.api.SpineCompilerCleanTask
 import io.spine.compiler.gradle.api.CompilerSettings
 import io.spine.compiler.gradle.api.CompilerTask
 import io.spine.compiler.gradle.api.Names.COMPILER_RAW_ARTIFACT
-import io.spine.compiler.gradle.api.Names.EXTENSION_NAME
 import io.spine.compiler.gradle.api.Names.PROTOBUF_GRADLE_PLUGIN_ID
 import io.spine.compiler.gradle.api.Names.SPINE_COMPILER_PROTOC_PLUGIN
 import io.spine.compiler.gradle.api.Names.USER_CLASSPATH_CONFIGURATION
 import io.spine.compiler.gradle.api.ProtocPluginArtifact
+import io.spine.compiler.gradle.api.SpineCompilerCleanTask
 import io.spine.compiler.gradle.api.compilerWorkingDir
 import io.spine.compiler.gradle.api.generatedDir
 import io.spine.compiler.gradle.plugin.GeneratedSubdir.GRPC
@@ -53,6 +52,8 @@ import io.spine.compiler.params.WorkingDirectory
 import io.spine.string.toBase64Encoded
 import io.spine.tools.code.SourceSetName
 import io.spine.tools.code.manifest.Version
+import io.spine.tools.gradle.lib.LibraryPlugin
+import io.spine.tools.gradle.lib.spineExtension
 import io.spine.tools.gradle.project.hasJava
 import io.spine.tools.gradle.project.hasJavaOrKotlin
 import io.spine.tools.gradle.project.hasKotlin
@@ -70,43 +71,54 @@ import org.gradle.api.tasks.Delete
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.exclude
-import org.gradle.kotlin.dsl.findByType
 import org.gradle.kotlin.dsl.register
-import org.gradle.api.Plugin as GradlePlugin
 
 /**
- * The ProtoData Gradle plugin.
+ * The Gradle plugin of the Spine Compiler.
  *
- * Adds the `launchProtoData` task which runs the executable with the arguments assembled from
- * the configuration of this plugin.
+ * Adds the `launchSpineCompiler` tasks which runs the executable with the arguments
+ * assembled from settings of this plugin.
  *
  * The users can submit configuration parameters, such as renderer and plugin class names, etc. via
- * the `protoData { }` extension.
+ * the `compiler { }` extension.
  *
- * The users can submit the user classpath to the ProtoData by declaring dependencies using
- * the `protoData` configuration.
+ * The users can submit the user classpath to the Compiler by declaring dependencies using
+ * the `spineCompiler` configuration.
  *
  * Example:
  * ```
- * protoData {
- *     renderers("com.acme.MyRenderer")
- *     plugins("com.acme.MyPlugin")
+ * spine {
+ *     compiler {
+ *         plugins("com.acme.MyPlugin")
+ *     }
  * }
  *
  * dependencies {
- *     protoData(project(":my-plugin"))
+ *     spineCompiler(project(":my-plugin"))
  * }
  * ```
  */
-public class Plugin : GradlePlugin<Project> {
+public class Plugin : LibraryPlugin<CompilerSettings>(
+    CompilerDslSpec()
+) {
 
+    init {
+        // Inject the access to the project so that `CompilerDslSpec` can
+        // create an instance of `Extension`.
+        (dslSpec as CompilerDslSpec).project = { this.project }
+    }
+
+    /**
+     * The version of the plugin.
+     */
     private val version: String by lazy {
         readVersion()
     }
 
     override fun apply(project: Project) {
+        super.apply(project)
+        createExtension()
         with(project) {
-            createExtension()
             createConfigurations(this@Plugin.version)
             createTasks()
             configureWithProtobufPlugin(this@Plugin.version)
@@ -133,21 +145,8 @@ public class Plugin : GradlePlugin<Project> {
  *
  * Or, if the extension is not yet added, creates it and returns.
  */
-internal val Project.extension: Extension
-    get() = extensions.findByType(CompilerSettings::class)?.run { this as Extension }
-        ?: createExtension()
-
-/**
- * Creates [Extension] associated with [Plugin] in this project.
- *
- * The extension is exposed by the type of [CompilerSettings] it implements to hide
- * the implementation details from the end-user projects.
- */
-private fun Project.createExtension(): Extension {
-    val extension = Extension(this)
-    extensions.add(CompilerSettings::class.java, EXTENSION_NAME, extension)
-    return extension
-}
+internal val Project.compilerSettings: Extension
+    get() = spineExtension<CompilerSettings>() as Extension
 
 /**
  * Creates configurations for `protoDataRawArtifact` and user-defined classpath,
@@ -205,7 +204,7 @@ private fun Project.createCleanTask(sourceSet: SourceSet) {
     val project = this
     val cleanSourceSet = SpineCompilerCleanTask.nameFor(sourceSet)
     tasks.register<Delete>(cleanSourceSet) {
-        delete(extension.outputDirs(sourceSet))
+        delete(compilerSettings.outputDirs(sourceSet))
 
         val spineCompilerCleanTask = this
         tasks.getByName("clean").dependsOn(spineCompilerCleanTask)

--- a/gradle-plugin/src/test/kotlin/io/spine/compiler/gradle/plugin/ExtensionSpec.kt
+++ b/gradle-plugin/src/test/kotlin/io/spine/compiler/gradle/plugin/ExtensionSpec.kt
@@ -29,7 +29,7 @@ package io.spine.compiler.gradle.plugin
 import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.gradle.ProtobufPlugin
 import io.kotest.matchers.shouldBe
-import io.spine.compiler.gradle.api.CodegenSettings
+import io.spine.compiler.gradle.api.CompilerSettings
 import io.spine.tools.gradle.project.sourceSets
 import java.io.File
 import kotlin.io.path.div
@@ -62,7 +62,7 @@ class ExtensionSpec {
             apply<ProtobufPlugin>()
             apply<Plugin>()
 
-            this@ExtensionSpec.extension = extensions.getByType<CodegenSettings>() as Extension
+            this@ExtensionSpec.extension = extensions.getByType<CompilerSettings>() as Extension
         }
     }
 

--- a/gradle-plugin/src/test/kotlin/io/spine/compiler/gradle/plugin/ExtensionSpec.kt
+++ b/gradle-plugin/src/test/kotlin/io/spine/compiler/gradle/plugin/ExtensionSpec.kt
@@ -29,7 +29,6 @@ package io.spine.compiler.gradle.plugin
 import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.gradle.ProtobufPlugin
 import io.kotest.matchers.shouldBe
-import io.spine.compiler.gradle.api.CompilerSettings
 import io.spine.tools.gradle.project.sourceSets
 import java.io.File
 import kotlin.io.path.div
@@ -37,7 +36,6 @@ import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.tasks.SourceSet.MAIN_SOURCE_SET_NAME
 import org.gradle.kotlin.dsl.apply
-import org.gradle.kotlin.dsl.getByType
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -62,7 +60,7 @@ class ExtensionSpec {
             apply<ProtobufPlugin>()
             apply<Plugin>()
 
-            this@ExtensionSpec.extension = extensions.getByType<CompilerSettings>() as Extension
+            this@ExtensionSpec.extension = project.compilerSettings
         }
     }
 

--- a/gradle-plugin/src/test/kotlin/io/spine/compiler/gradle/plugin/ProjectConfigSpec.kt
+++ b/gradle-plugin/src/test/kotlin/io/spine/compiler/gradle/plugin/ProjectConfigSpec.kt
@@ -50,7 +50,6 @@ import org.junit.jupiter.api.io.TempDir
 @DisplayName("Plugin configuration should")
 class ProjectConfigSpec {
 
-    @Suppress("HasPlatformType")
     companion object {
 
         val mainCompilerTask = CompilerTaskName(SourceSetName.main).value()

--- a/gradle-plugin/src/test/kotlin/io/spine/compiler/gradle/plugin/ProjectConfigSpec.kt
+++ b/gradle-plugin/src/test/kotlin/io/spine/compiler/gradle/plugin/ProjectConfigSpec.kt
@@ -29,8 +29,9 @@ package io.spine.compiler.gradle.plugin
 import com.google.common.truth.Correspondence
 import com.google.common.truth.Truth.assertThat
 import com.google.protobuf.gradle.ProtobufPlugin
+import io.kotest.matchers.shouldNotBe
 import io.spine.compiler.gradle.api.CompilerTaskName
-import io.spine.compiler.gradle.api.Names.EXTENSION_NAME
+import io.spine.compiler.gradle.api.compilerSettings
 import io.spine.tools.code.SourceSetName
 import io.spine.tools.gradle.project.sourceSets
 import java.io.File
@@ -43,6 +44,7 @@ import org.gradle.testfixtures.ProjectBuilder
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.io.TempDir
 
 @DisplayName("Plugin configuration should")
@@ -89,15 +91,14 @@ class ProjectConfigSpec {
 
     @Test
     fun `add extension`() {
-        val assertExtension = assertThat(project.extensions.getByName(EXTENSION_NAME))
-        assertExtension
-            .isNotNull()
-        assertExtension
-            .isInstanceOf(Extension::class.java)
+        assertDoesNotThrow {
+            project.compilerSettings
+        }
+        project.compilerSettings shouldNotBe null
     }
 
     @Test
-    fun `bind 'launchProtoData' to Java compilation`() {
+    fun `bind 'launchSpineCompiler' to Java compilation`() {
         val task = project.tasks.getByName("compileJava")
         assertThat(task.dependsOn)
             .comparingElementsUsing(taskNames)

--- a/params/src/main/kotlin/io/spine/compiler/params/CodeGeneratorRequestFile.kt
+++ b/params/src/main/kotlin/io/spine/compiler/params/CodeGeneratorRequestFile.kt
@@ -26,7 +26,7 @@
 
 package io.spine.compiler.params
 
-import io.spine.compiler.params.Directories.PROTODATA_WORKING_DIR
+import io.spine.compiler.params.Directories.COMPILER_WORKING_DIR
 import io.spine.compiler.params.Directories.REQUESTS_SUBDIR
 import io.spine.tools.code.SourceSetName
 
@@ -40,7 +40,7 @@ public object CodeGeneratorRequestFile {
      * request files are placed.
      */
     @Suppress("ConstPropertyName") // https://bit.ly/kotlin-prop-names
-    public const val defaultDirectory: String = "$PROTODATA_WORKING_DIR/$REQUESTS_SUBDIR"
+    public const val defaultDirectory: String = "$COMPILER_WORKING_DIR/$REQUESTS_SUBDIR"
 
     /**
      * Obtains the name of the file with the code generation request for the given source set.

--- a/params/src/main/kotlin/io/spine/compiler/params/Directories.kt
+++ b/params/src/main/kotlin/io/spine/compiler/params/Directories.kt
@@ -32,25 +32,25 @@ package io.spine.compiler.params
 public object Directories {
 
     /**
-     * The name of the ProtoData working directory which is conventionally
-     * placed under the `build` directory.
+     * The name of the Compiler working directory which is conventionally
+     * placed under the `build/spine` directory.
      */
-    public const val PROTODATA_WORKING_DIR: String = "protodata"
+    public const val COMPILER_WORKING_DIR: String = "compiler"
 
     /**
-     * The name of the subdirectory under [PROTODATA_WORKING_DIR] for storing
+     * The name of the subdirectory under [COMPILER_WORKING_DIR] for storing
      * files passed as parameters to pipelines.
      */
     public const val PARAMETERS_SUBDIR: String = "parameters"
 
     /**
-     * The name of the subdirectory under [PROTODATA_WORKING_DIR] where
+     * The name of the subdirectory under [COMPILER_WORKING_DIR] where
      * the ProtoData settings files are stored.
      */
     public const val SETTINGS_SUBDIR: String = "settings"
 
     /**
-     * The name of the subdirectory under [PROTODATA_WORKING_DIR] where
+     * The name of the subdirectory under [COMPILER_WORKING_DIR] where
      * [code generation requests files][CodeGeneratorRequestFile] are stored.
      */
     public const val REQUESTS_SUBDIR: String = "requests"

--- a/pom.xml
+++ b/pom.xml
@@ -134,25 +134,25 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-gradle-plugin-api</artifactId>
-    <version>2.0.0-SNAPSHOT.334</version>
+    <version>2.0.0-SNAPSHOT.335</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>2.0.0-SNAPSHOT.334</version>
+    <version>2.0.0-SNAPSHOT.335</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-psi-java</artifactId>
-    <version>2.0.0-SNAPSHOT.334</version>
+    <version>2.0.0-SNAPSHOT.335</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-tool-base</artifactId>
-    <version>2.0.0-SNAPSHOT.334</version>
+    <version>2.0.0-SNAPSHOT.335</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -224,7 +224,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.334</version>
+    <version>2.0.0-SNAPSHOT.335</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,12 @@ all modules and does not describe the project structure per-subproject.
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
+    <artifactId>spine-gradle-plugin-api</artifactId>
+    <version>2.0.0-SNAPSHOT.334</version>
+    <scope>compile</scope>
+  </dependency>
+  <dependency>
+    <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
     <version>2.0.0-SNAPSHOT.334</version>
     <scope>compile</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.compiler</groupId>
 <artifactId>spine-compiler</artifactId>
-<version>2.0.0-SNAPSHOT.007</version>
+<version>2.0.0-SNAPSHOT.008</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -134,19 +134,19 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-base</artifactId>
-    <version>2.0.0-SNAPSHOT.333</version>
+    <version>2.0.0-SNAPSHOT.334</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-psi-java</artifactId>
-    <version>2.0.0-SNAPSHOT.333</version>
+    <version>2.0.0-SNAPSHOT.334</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-tool-base</artifactId>
-    <version>2.0.0-SNAPSHOT.333</version>
+    <version>2.0.0-SNAPSHOT.334</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -218,7 +218,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-plugin-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.333</version>
+    <version>2.0.0-SNAPSHOT.334</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/tests/consumer/build.gradle.kts
+++ b/tests/consumer/build.gradle.kts
@@ -30,6 +30,7 @@ import io.spine.dependency.lib.JavaX
 import io.spine.dependency.local.Base
 import io.spine.dependency.local.Spine
 import io.spine.compiler.gradle.api.CompilerSettings
+import io.spine.tools.gradle.root.rootExtension
 
 buildscript {
     standardSpineSdkRepositories()
@@ -50,7 +51,7 @@ dependencies {
     testImplementation(Base.lib)?.because("tests use packing and unpacking extension functions.")
 }
 
-extensions.getByType<CompilerSettings>().apply {
+rootExtension.extensions.getByType<CompilerSettings>().apply {
     plugins(
         "io.spine.compiler.test.uuid.UuidPlugin",
         "io.spine.compiler.test.annotation.AnnotationPlugin"

--- a/tests/consumer/build.gradle.kts
+++ b/tests/consumer/build.gradle.kts
@@ -29,7 +29,7 @@
 import io.spine.dependency.lib.JavaX
 import io.spine.dependency.local.Base
 import io.spine.dependency.local.Spine
-import io.spine.compiler.gradle.api.CodegenSettings
+import io.spine.compiler.gradle.api.CompilerSettings
 
 buildscript {
     standardSpineSdkRepositories()
@@ -50,7 +50,7 @@ dependencies {
     testImplementation(Base.lib)?.because("tests use packing and unpacking extension functions.")
 }
 
-extensions.getByType<CodegenSettings>().apply {
+extensions.getByType<CompilerSettings>().apply {
     plugins(
         "io.spine.compiler.test.uuid.UuidPlugin",
         "io.spine.compiler.test.annotation.AnnotationPlugin"

--- a/tests/in-place-consumer/build.gradle.kts
+++ b/tests/in-place-consumer/build.gradle.kts
@@ -46,9 +46,11 @@ dependencies {
 
 val protobufDir = "$projectDir/proto-gen/"
 
-compiler {
-    plugins(
-        "io.spine.compiler.test.uuid.UuidPlugin"
-    )
-    outputBaseDir.set(project.layout.projectDirectory.dir(protobufDir))
+spine {
+    compiler {
+        plugins(
+            "io.spine.compiler.test.uuid.UuidPlugin"
+        )
+        outputBaseDir.set(project.layout.projectDirectory.dir(protobufDir))
+    }
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.dependency.local.Spine].
  */
-val compilerVersion: String by extra("2.0.0-SNAPSHOT.007")
+val compilerVersion: String by extra("2.0.0-SNAPSHOT.008")


### PR DESCRIPTION
This PR continues the efforts of renaming ProtoData to Spine Compiler and introducing Gradle DSL that goes under the `spine` root project extension.

### Changes in details
 * `CodegenSettings` interface was renamed to `CompilerSettings`.
 * Constants and properties mentioning ProtoData were renamed.
 * `Project.codegenSettings` was renamed to `compilerSettings`. The property now uses `spineExtension()` function to reflect the nesting of the Compiler project extension.
 * The layout of `PluginSpec` test suite was imported so that project creation and configuration functions come right after the `@BeforeEach` function thus clarifying the setup of a test.
 * Test projects were updated to have `spine { compiler { ... } }` blocks.
