### PR TITLE
Finish renaming

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:compiler-api:2.0.0-SNAPSHOT.010`
+# Dependencies of `io.spine.tools:compiler-api:2.0.0-SNAPSHOT.011`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -1076,12 +1076,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 08 21:00:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 14 21:52:23 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-api-tests:2.0.0-SNAPSHOT.010`
+# Dependencies of `io.spine.tools:compiler-api-tests:2.0.0-SNAPSHOT.011`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1881,12 +1881,12 @@ This report was generated on **Sun Jun 08 21:00:39 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 08 21:00:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 14 21:52:23 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-backend:2.0.0-SNAPSHOT.010`
+# Dependencies of `io.spine.tools:compiler-backend:2.0.0-SNAPSHOT.011`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -2962,12 +2962,12 @@ This report was generated on **Sun Jun 08 21:00:39 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 08 21:00:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 14 21:52:23 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-cli:2.0.0-SNAPSHOT.010`
+# Dependencies of `io.spine.tools:compiler-cli:2.0.0-SNAPSHOT.011`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -4067,12 +4067,12 @@ This report was generated on **Sun Jun 08 21:00:39 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 08 21:00:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 14 21:52:23 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-gradle-api:2.0.0-SNAPSHOT.010`
+# Dependencies of `io.spine.tools:compiler-gradle-api:2.0.0-SNAPSHOT.011`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -5083,12 +5083,12 @@ This report was generated on **Sun Jun 08 21:00:39 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 08 21:00:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 14 21:52:23 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-gradle-plugin:2.0.0-SNAPSHOT.010`
+# Dependencies of `io.spine.tools:compiler-gradle-plugin:2.0.0-SNAPSHOT.011`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -6147,12 +6147,12 @@ This report was generated on **Sun Jun 08 21:00:39 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 08 21:00:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 14 21:52:23 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-jvm:2.0.0-SNAPSHOT.010`
+# Dependencies of `io.spine.tools:compiler-jvm:2.0.0-SNAPSHOT.011`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -7228,12 +7228,12 @@ This report was generated on **Sun Jun 08 21:00:39 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 08 21:00:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 14 21:52:23 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-params:2.0.0-SNAPSHOT.010`
+# Dependencies of `io.spine.tools:compiler-params:2.0.0-SNAPSHOT.011`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -8301,12 +8301,12 @@ This report was generated on **Sun Jun 08 21:00:39 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 08 21:00:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 14 21:52:23 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-protoc-plugin:2.0.0-SNAPSHOT.010`
+# Dependencies of `io.spine.tools:compiler-protoc-plugin:2.0.0-SNAPSHOT.011`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9109,12 +9109,12 @@ This report was generated on **Sun Jun 08 21:00:39 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 08 21:00:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 14 21:52:23 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-test-env:2.0.0-SNAPSHOT.010`
+# Dependencies of `io.spine.tools:compiler-test-env:2.0.0-SNAPSHOT.011`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -10186,12 +10186,12 @@ This report was generated on **Sun Jun 08 21:00:39 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 08 21:00:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 14 21:52:23 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-testlib:2.0.0-SNAPSHOT.010`
+# Dependencies of `io.spine.tools:compiler-testlib:2.0.0-SNAPSHOT.011`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -11365,4 +11365,4 @@ This report was generated on **Sun Jun 08 21:00:39 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 08 21:00:39 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Jun 14 21:52:23 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/jvm/src/main/kotlin/io/spine/tools/compiler/jvm/file/SourceFileSetExts.kt
+++ b/jvm/src/main/kotlin/io/spine/tools/compiler/jvm/file/SourceFileSetExts.kt
@@ -24,15 +24,33 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-@file:JvmName("SourceFiles")
+@file:JvmName("SourceFileSets")
 
 package io.spine.tools.compiler.jvm.file
 
-import io.spine.tools.compiler.render.SourceFile
-import kotlin.io.path.extension
+import io.spine.tools.compiler.render.SourceFileSet
 
 /**
- * Tells if this is a Java source file.
+ * Tells if this source file set produces files that reside under the `java` directory.
+ *
+ * @see hasGrpcRoot
  */
-public val SourceFile<*>.isJava: Boolean
-    get() = relativePath.extension == "java"
+@get:JvmName("hasJavaRoot")
+public val SourceFileSet.hasJavaRoot: Boolean
+    get() = outputRoot.endsWith("java")
+
+/**
+ * Tells if this source file set produces files that reside under the `grpc` directory.
+ *
+ * @see hasJavaRoot
+ */
+@get:JvmName("hasGrpcRoot")
+public val SourceFileSet.hasGrpcRoot: Boolean
+    get() = outputRoot.endsWith("grpc")
+
+/**
+ * Tells if this source file set has at least one Java file.
+ */
+@get:JvmName("hasJavaFiles")
+public val SourceFileSet.hasJavaFiles: Boolean
+    get() = any { it.isJava }

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>spine-compiler</artifactId>
-<version>2.0.0-SNAPSHOT.010</version>
+<version>2.0.0-SNAPSHOT.011</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -33,7 +33,6 @@ import io.spine.dependency.lib.Protobuf
 import io.spine.dependency.local.Base
 import io.spine.dependency.local.CoreJava
 import io.spine.dependency.local.Logging
-import io.spine.dependency.local.ProtoData
 import io.spine.dependency.local.Reflect
 import io.spine.dependency.local.ToolBase
 import io.spine.dependency.local.Validation
@@ -101,11 +100,7 @@ subprojects {
                     Logging.libJvm,
                     Logging.middleware,
                     Reflect.lib,
-                    ProtoData.api,
-                    ProtoData.backend,
-                    ProtoData.params,
                     CoreJava.server,
-                    ProtoData.java,
                 )
             }
         }

--- a/tests/compiler-extension/src/main/java/io/spine/tools/compiler/test/annotation/AnnotationRenderer.java
+++ b/tests/compiler-extension/src/main/java/io/spine/tools/compiler/test/annotation/AnnotationRenderer.java
@@ -34,6 +34,8 @@ import io.spine.tools.compiler.test.FieldId;
 import java.nio.file.Path;
 import java.util.Set;
 
+import static io.spine.tools.compiler.jvm.file.SourceFileSets.hasJavaRoot;
+
 /**
  * Renders Java annotations on field getters for fields marked with
  * the {@code (java_annotation)} option.
@@ -45,23 +47,23 @@ public final class AnnotationRenderer extends JavaRenderer {
 
     @Override
     protected void render(SourceFileSet sources) {
-        // Don't do anything if this source file set is for a language
-        // other than Java. For the root cause of this please see this issue:
-        // https://github.com/SpineEventEngine/ProtoData/issues/90
-         if (!sources.inputRoot().endsWith("java")) {
-             return;
-         }
+        // Don't do anything if this source file set is for a language other than Java.
+        if (!hasJavaRoot(sources)) {
+            return;
+        }
         var annotatedFields = select(Annotated.class).all();
         annotatedFields.forEach(field -> renderFor(field, sources));
 
+        var nl = System.lineSeparator();
         sources.forEach(file -> {
            file.at(new MessageClass())
                .withExtraIndentation(2)
                // Use the deprecated annotation because `io.spine.annotation.Generated`
-               // is used by default.
-               .add("@javax.annotation.Generated(" + System.lineSeparator() +
-                    "    \"by Spine Compiler tests\"" + System.lineSeparator() +
-                    ")");
+               // is used by default, and it is not repeated.
+               .add("@javax.annotation.Generated(" + nl +
+                    "    \"by Spine Compiler tests\"" + nl +
+                    ")"
+               );
         });
     }
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.dependency.local.Spine].
  */
-val compilerVersion: String by extra("2.0.0-SNAPSHOT.010")
+val compilerVersion: String by extra("2.0.0-SNAPSHOT.011")


### PR DESCRIPTION
This PR concludes the preparational steps associated with renaming of ProtoData to the Spine Compiler.

This project still depends on ProtoData and refers to it in several build files, e.g., in `test-module.gradle.kts`. This dependency will be migrated to Core JVM Compiler in one of the further pull requests.
