### PR TITLE
Update ToolBase usage

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -34,13 +34,16 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object ToolBase {
     const val group = Spine.toolsGroup
-    const val version = "2.0.0-SNAPSHOT.335"
+    const val version = "2.0.0-SNAPSHOT.340"
 
     const val lib = "$group:spine-tool-base:$version"
     const val pluginBase = "$group:spine-plugin-base:$version"
     const val gradleRootPlugin = "$group:spine-gradle-root-plugin:$version"
     const val gradlePluginApi = "$group:spine-gradle-plugin-api:$version"
     const val pluginTestlib = "$group:spine-plugin-testlib:$version"
+
+    const val jvmUtil = "$group:jvm-util:$version"
+    const val jvmUtilPlugin = "$group:jvm-util-plugin:$version"
 
     const val intellijPlatformJava = "$group:intellij-platform-java:$version"
 


### PR DESCRIPTION
## Summary
- bump ToolBase version to 2.0.0-SNAPSHOT.340
- expose new `jvmUtil` and `jvmUtilPlugin` coordinates in `ToolBase` dependency object

## Testing
- `./gradlew --no-daemon check` *(fails: could not find Java toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_6858844dabc08333a8f8aa32a1a2ea3e