### PR TITLE
Make Compiler Gradle Plugin specify the Protobuf `protoc` artifact

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -34,7 +34,7 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object ToolBase {
     const val group = Spine.toolsGroup
-    const val version = "2.0.0-SNAPSHOT.354"
+    const val version = "2.0.0-SNAPSHOT.355"
 
     const val lib = "$group:tool-base:$version"
     const val pluginBase = "$group:plugin-base:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -34,7 +34,7 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object ToolBase {
     const val group = Spine.toolsGroup
-    const val version = "2.0.0-SNAPSHOT.350"
+    const val version = "2.0.0-SNAPSHOT.352"
 
     const val lib = "$group:tool-base:$version"
     const val pluginBase = "$group:plugin-base:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -34,7 +34,7 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object ToolBase {
     const val group = Spine.toolsGroup
-    const val version = "2.0.0-SNAPSHOT.353"
+    const val version = "2.0.0-SNAPSHOT.354"
 
     const val lib = "$group:tool-base:$version"
     const val pluginBase = "$group:plugin-base:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -34,7 +34,7 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object ToolBase {
     const val group = Spine.toolsGroup
-    const val version = "2.0.0-SNAPSHOT.352"
+    const val version = "2.0.0-SNAPSHOT.353"
 
     const val lib = "$group:tool-base:$version"
     const val pluginBase = "$group:plugin-base:$version"

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:compiler-api:2.0.0-SNAPSHOT.012`
+# Dependencies of `io.spine.tools:compiler-api:2.0.0-SNAPSHOT.013`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -1098,14 +1098,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 15:15:46 WEST 2025** using 
+This report was generated on **Fri Sep 19 21:36:29 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-api-tests:2.0.0-SNAPSHOT.012`
+# Dependencies of `io.spine.tools:compiler-api-tests:2.0.0-SNAPSHOT.013`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1916,14 +1916,14 @@ This report was generated on **Fri Sep 19 15:15:46 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 15:15:46 WEST 2025** using 
+This report was generated on **Fri Sep 19 21:36:29 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-backend:2.0.0-SNAPSHOT.012`
+# Dependencies of `io.spine.tools:compiler-backend:2.0.0-SNAPSHOT.013`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -3021,14 +3021,14 @@ This report was generated on **Fri Sep 19 15:15:46 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 15:15:46 WEST 2025** using 
+This report was generated on **Fri Sep 19 21:36:29 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-cli:2.0.0-SNAPSHOT.012`
+# Dependencies of `io.spine.tools:compiler-cli:2.0.0-SNAPSHOT.013`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -4150,14 +4150,14 @@ This report was generated on **Fri Sep 19 15:15:46 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 15:15:46 WEST 2025** using 
+This report was generated on **Fri Sep 19 21:36:29 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-gradle-api:2.0.0-SNAPSHOT.012`
+# Dependencies of `io.spine.tools:compiler-gradle-api:2.0.0-SNAPSHOT.013`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -5190,14 +5190,14 @@ This report was generated on **Fri Sep 19 15:15:46 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 15:15:46 WEST 2025** using 
+This report was generated on **Fri Sep 19 21:36:29 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-gradle-plugin:2.0.0-SNAPSHOT.012`
+# Dependencies of `io.spine.tools:compiler-gradle-plugin:2.0.0-SNAPSHOT.013`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -6278,14 +6278,14 @@ This report was generated on **Fri Sep 19 15:15:46 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 15:15:46 WEST 2025** using 
+This report was generated on **Fri Sep 19 21:36:39 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-jvm:2.0.0-SNAPSHOT.012`
+# Dependencies of `io.spine.tools:compiler-jvm:2.0.0-SNAPSHOT.013`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -7383,14 +7383,14 @@ This report was generated on **Fri Sep 19 15:15:46 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 15:15:46 WEST 2025** using 
+This report was generated on **Fri Sep 19 21:36:29 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-params:2.0.0-SNAPSHOT.012`
+# Dependencies of `io.spine.tools:compiler-params:2.0.0-SNAPSHOT.013`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -8480,14 +8480,14 @@ This report was generated on **Fri Sep 19 15:15:46 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 15:15:46 WEST 2025** using 
+This report was generated on **Fri Sep 19 21:36:29 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-protoc-plugin:2.0.0-SNAPSHOT.012`
+# Dependencies of `io.spine.tools:compiler-protoc-plugin:2.0.0-SNAPSHOT.013`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9296,14 +9296,14 @@ This report was generated on **Fri Sep 19 15:15:46 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 15:15:46 WEST 2025** using 
+This report was generated on **Fri Sep 19 21:36:29 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-test-env:2.0.0-SNAPSHOT.012`
+# Dependencies of `io.spine.tools:compiler-test-env:2.0.0-SNAPSHOT.013`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -10397,14 +10397,14 @@ This report was generated on **Fri Sep 19 15:15:46 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 15:15:46 WEST 2025** using 
+This report was generated on **Fri Sep 19 21:36:29 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-testlib:2.0.0-SNAPSHOT.012`
+# Dependencies of `io.spine.tools:compiler-testlib:2.0.0-SNAPSHOT.013`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -11605,6 +11605,6 @@ This report was generated on **Fri Sep 19 15:15:46 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 15:15:46 WEST 2025** using 
+This report was generated on **Fri Sep 19 21:36:29 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1098,7 +1098,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 01:26:38 WEST 2025** using 
+This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -1916,7 +1916,7 @@ This report was generated on **Sat Sep 20 01:26:38 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 01:26:38 WEST 2025** using 
+This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -3021,7 +3021,7 @@ This report was generated on **Sat Sep 20 01:26:38 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 01:26:38 WEST 2025** using 
+This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -4150,7 +4150,7 @@ This report was generated on **Sat Sep 20 01:26:38 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 01:26:37 WEST 2025** using 
+This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -5190,7 +5190,7 @@ This report was generated on **Sat Sep 20 01:26:37 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 01:26:37 WEST 2025** using 
+This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -6278,7 +6278,7 @@ This report was generated on **Sat Sep 20 01:26:37 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 01:26:38 WEST 2025** using 
+This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -7383,7 +7383,7 @@ This report was generated on **Sat Sep 20 01:26:38 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 01:26:37 WEST 2025** using 
+This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -8480,7 +8480,7 @@ This report was generated on **Sat Sep 20 01:26:37 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 01:26:37 WEST 2025** using 
+This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -9296,7 +9296,7 @@ This report was generated on **Sat Sep 20 01:26:37 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 01:26:37 WEST 2025** using 
+This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -10397,7 +10397,7 @@ This report was generated on **Sat Sep 20 01:26:37 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 01:26:37 WEST 2025** using 
+This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -11605,6 +11605,6 @@ This report was generated on **Sat Sep 20 01:26:37 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 01:26:38 WEST 2025** using 
+This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1098,7 +1098,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using 
+This report was generated on **Sat Sep 20 01:26:38 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -1916,7 +1916,7 @@ This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using 
+This report was generated on **Sat Sep 20 01:26:38 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -3021,7 +3021,7 @@ This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using 
+This report was generated on **Sat Sep 20 01:26:38 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -4150,7 +4150,7 @@ This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using 
+This report was generated on **Sat Sep 20 01:26:37 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -5190,7 +5190,7 @@ This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using 
+This report was generated on **Sat Sep 20 01:26:37 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -6278,7 +6278,7 @@ This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using 
+This report was generated on **Sat Sep 20 01:26:38 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -7383,7 +7383,7 @@ This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using 
+This report was generated on **Sat Sep 20 01:26:37 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -8480,7 +8480,7 @@ This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using 
+This report was generated on **Sat Sep 20 01:26:37 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -9296,7 +9296,7 @@ This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using 
+This report was generated on **Sat Sep 20 01:26:37 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -10397,7 +10397,7 @@ This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using 
+This report was generated on **Sat Sep 20 01:26:37 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -11605,6 +11605,6 @@ This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using 
+This report was generated on **Sat Sep 20 01:26:38 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1098,7 +1098,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using 
+This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -1916,7 +1916,7 @@ This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using 
+This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -3021,7 +3021,7 @@ This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using 
+This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -4150,7 +4150,7 @@ This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using 
+This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -5190,7 +5190,7 @@ This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using 
+This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -6278,7 +6278,7 @@ This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using 
+This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -7383,7 +7383,7 @@ This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using 
+This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -8480,7 +8480,7 @@ This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using 
+This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -9296,7 +9296,7 @@ This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using 
+This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -10397,7 +10397,7 @@ This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using 
+This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -11605,6 +11605,6 @@ This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 02:06:44 WEST 2025** using 
+This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1098,7 +1098,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 21:36:29 WEST 2025** using 
+This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -1916,7 +1916,7 @@ This report was generated on **Fri Sep 19 21:36:29 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 21:36:29 WEST 2025** using 
+This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -3021,7 +3021,7 @@ This report was generated on **Fri Sep 19 21:36:29 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 21:36:29 WEST 2025** using 
+This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -4150,7 +4150,7 @@ This report was generated on **Fri Sep 19 21:36:29 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 21:36:29 WEST 2025** using 
+This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -5190,7 +5190,7 @@ This report was generated on **Fri Sep 19 21:36:29 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 21:36:29 WEST 2025** using 
+This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -6278,7 +6278,7 @@ This report was generated on **Fri Sep 19 21:36:29 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 21:36:39 WEST 2025** using 
+This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -7383,7 +7383,7 @@ This report was generated on **Fri Sep 19 21:36:39 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 21:36:29 WEST 2025** using 
+This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -8480,7 +8480,7 @@ This report was generated on **Fri Sep 19 21:36:29 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 21:36:29 WEST 2025** using 
+This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -9296,7 +9296,7 @@ This report was generated on **Fri Sep 19 21:36:29 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 21:36:29 WEST 2025** using 
+This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -10397,7 +10397,7 @@ This report was generated on **Fri Sep 19 21:36:29 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 21:36:29 WEST 2025** using 
+This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -11605,6 +11605,6 @@ This report was generated on **Fri Sep 19 21:36:29 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 19 21:36:29 WEST 2025** using 
+This report was generated on **Fri Sep 19 23:41:52 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1098,7 +1098,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using 
+This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -1916,7 +1916,7 @@ This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using 
+This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -3021,7 +3021,7 @@ This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using 
+This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -4150,7 +4150,7 @@ This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using 
+This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -5190,7 +5190,7 @@ This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using 
+This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -6278,7 +6278,7 @@ This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using 
+This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -7383,7 +7383,7 @@ This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using 
+This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -8480,7 +8480,7 @@ This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using 
+This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -9296,7 +9296,7 @@ This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using 
+This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -10397,7 +10397,7 @@ This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using 
+This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -11605,6 +11605,6 @@ This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 15:02:35 WEST 2025** using 
+This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/gradle-api/build.gradle.kts
+++ b/gradle-api/build.gradle.kts
@@ -33,6 +33,7 @@ plugins {
 dependencies {
     compileOnly(gradleApi())
 
+    implementation(ToolBase.jvmTools)
     implementation(ToolBase.pluginBase)
     implementation(ToolBase.gradlePluginApi)
     implementation(project(":api"))

--- a/gradle-api/src/main/kotlin/io/spine/tools/compiler/gradle/api/Artifacts.kt
+++ b/gradle-api/src/main/kotlin/io/spine/tools/compiler/gradle/api/Artifacts.kt
@@ -45,12 +45,12 @@ public object Artifacts {
     public val compilerBackend: Module = Module(group, "compiler-backend")
 
     /**
-     * The name of the Compiler Gradle Plugin artifact.
+     * The module of the Compiler Gradle Plugin artifact.
      */
     public val compilerGradlePlugin: Module = Module(group, "compiler-gradle-plugin")
 
     /**
-     * The `protoc` artifact of Google Protobuf.
+     * The module of the `protoc` artifact of Google Protobuf.
      */
     public val protobufProtocArtifact: Module = Module("com.google.protobuf", "protoc")
 

--- a/gradle-api/src/main/kotlin/io/spine/tools/compiler/gradle/api/Artifacts.kt
+++ b/gradle-api/src/main/kotlin/io/spine/tools/compiler/gradle/api/Artifacts.kt
@@ -26,6 +26,8 @@
 
 package io.spine.tools.compiler.gradle.api
 
+import io.spine.tools.meta.Module
+
 /**
  * Constants for locating the Compiler artifacts in Maven repositories.
  */
@@ -40,10 +42,20 @@ public object Artifacts {
     /**
      * The name of the Compiler Backend artifact.
      */
-    public const val compilerBackend: String = "compiler-backend"
+    public val compilerBackend: Module = Module(group, "compiler-backend")
 
     /**
-     * Obtains Maven coordinates of the `fat-cli` variant of command-line application.
+     * The name of the Compiler Gradle Plugin artifact.
+     */
+    public val compilerGradlePlugin: Module = Module(group, "compiler-gradle-plugin")
+
+    /**
+     * The `protoc` artifact of Google Protobuf.
+     */
+    public val protobufProtocArtifact: Module = Module("com.google.protobuf", "protoc")
+
+    /**
+     * Obtains Maven coordinates of the `fat-cli` variant of the command-line application.
      *
      * "fat-cli" is an all-in-one distribution of the Compiler, published somewhat in the past.
      * Ironically, we need it in the Compiler development.

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -41,7 +41,13 @@ plugins {
     `write-manifest`
 }
 
+/**
+ * The ID used for publishing this module.
+ */
+val moduleArtifactId = "compiler-gradle-plugin"
+
 artifactMeta {
+    artifactId.set(moduleArtifactId)
     // Add `protoc` as an explicit dependency as we pass it on to
     // `protobuf/protoc/artifact` when configuring a project.
     addDependencies(Protobuf.compiler)
@@ -146,7 +152,7 @@ publishing {
     }
     publications.withType<MavenPublication>().all {
         groupId = "io.spine.tools"
-        artifactId = "compiler-gradle-plugin"
+        artifactId = moduleArtifactId
         version = compilerVersion
     }
 }

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -42,6 +42,9 @@ plugins {
 }
 
 artifactMeta {
+    // Add `protoc` as an explicit dependency as we pass it on to
+    // `protobuf/protoc/artifact` when configuring a project.
+    addDependencies(Protobuf.compiler)
     excludeConfigurations {
         containing(
             "errorprone",

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -41,6 +41,21 @@ plugins {
     `write-manifest`
 }
 
+artifactMeta {
+    excludeConfigurations {
+        containing(
+            "errorprone",
+            "detekt",
+            "jacoco",
+            "pmd",
+            "checkstyle",
+            "ksp",
+            "dokka",
+            "jvm-tools",
+        )
+    }
+}
+
 @Suppress(
     "UnstableApiUsage" /* testing suites feature */,
     "unused" /* suite variable names obtained via `by` calls. */

--- a/gradle-plugin/src/functionalTest/resources/android-library/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/android-library/build.gradle.kts
@@ -60,12 +60,6 @@ dependencies {
     spineCompiler("io.spine.tools:compiler-test-env:+")
 }
 
-protobuf {
-    protoc {
-        artifact = io.spine.dependency.lib.Protobuf.compiler
-    }
-}
-
 android {
     compileSdkVersion = "android-31"
 }

--- a/gradle-plugin/src/functionalTest/resources/android-library/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/android-library/build.gradle.kts
@@ -25,6 +25,11 @@
  */
 
 import com.google.protobuf.gradle.protobuf
+import io.spine.dependency.lib.Grpc
+import io.spine.dependency.local.Base
+import io.spine.dependency.local.CoreJava
+import io.spine.dependency.local.Reflect
+import io.spine.dependency.local.TestLib
 import io.spine.gradle.repo.standardToSpineSdk
 
 buildscript {
@@ -63,4 +68,12 @@ protobuf {
 
 android {
     compileSdkVersion = "android-31"
+}
+
+configurations.all {
+    resolutionStrategy {
+        force(
+            io.spine.dependency.local.Base.lib,
+        )
+    }
 }

--- a/gradle-plugin/src/functionalTest/resources/copy-grpc/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/copy-grpc/build.gradle.kts
@@ -65,9 +65,6 @@ dependencies {
 }
 
 protobuf {
-    protoc {
-        artifact = io.spine.dependency.lib.Protobuf.compiler
-    }
     plugins {
         id("grpc") {
             artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}"

--- a/gradle-plugin/src/functionalTest/resources/copy-grpc/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/copy-grpc/build.gradle.kts
@@ -44,6 +44,15 @@ repositories {
     standardToSpineSdk()
 }
 
+
+configurations.all {
+    resolutionStrategy {
+        force(
+            io.spine.dependency.local.Base.lib,
+        )
+    }
+}
+
 val grpcVersion = "1.50.2"
 
 dependencies {

--- a/gradle-plugin/src/functionalTest/resources/empty-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/empty-test/build.gradle.kts
@@ -55,12 +55,6 @@ dependencies {
     spineCompiler("io.spine.tools:compiler-test-env:+")
 }
 
-protobuf {
-    protoc {
-        artifact = io.spine.dependency.lib.Protobuf.compiler
-    }
-}
-
 spine {
     compiler {
         plugins(

--- a/gradle-plugin/src/functionalTest/resources/empty-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/empty-test/build.gradle.kts
@@ -43,6 +43,14 @@ repositories {
     standardToSpineSdk()
 }
 
+configurations.all {
+    resolutionStrategy {
+        force(
+            io.spine.dependency.local.Base.lib,
+        )
+    }
+}
+
 dependencies {
     spineCompiler("io.spine.tools:compiler-test-env:+")
 }

--- a/gradle-plugin/src/functionalTest/resources/java-kotlin-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/java-kotlin-test/build.gradle.kts
@@ -52,6 +52,13 @@ spine {
         )
     }
 }
+configurations.all {
+    resolutionStrategy {
+        force(
+            io.spine.dependency.local.Base.lib,
+        )
+    }
+}
 
 dependencies {
     spineCompiler("io.spine.tools:compiler-test-env:+")

--- a/gradle-plugin/src/functionalTest/resources/java-kotlin-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/java-kotlin-test/build.gradle.kts
@@ -64,9 +64,3 @@ dependencies {
     spineCompiler("io.spine.tools:compiler-test-env:+")
     Protobuf.libs.forEach { implementation(it) }
 }
-
-protobuf {
-    protoc {
-        artifact = io.spine.dependency.lib.Protobuf.compiler
-    }
-}

--- a/gradle-plugin/src/functionalTest/resources/java-library-kotlin-jvm/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/java-library-kotlin-jvm/build.gradle.kts
@@ -65,9 +65,3 @@ dependencies {
     spineCompiler("io.spine.tools:compiler-test-env:+")
     Protobuf.libs.forEach { implementation(it) }
 }
-
-protobuf {
-    protoc {
-        artifact = io.spine.dependency.lib.Protobuf.compiler
-    }
-}

--- a/gradle-plugin/src/functionalTest/resources/java-library-kotlin-jvm/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/java-library-kotlin-jvm/build.gradle.kts
@@ -53,6 +53,14 @@ spine {
     }
 }
 
+configurations.all {
+    resolutionStrategy {
+        force(
+            io.spine.dependency.local.Base.lib,
+        )
+    }
+}
+
 dependencies {
     spineCompiler("io.spine.tools:compiler-test-env:+")
     Protobuf.libs.forEach { implementation(it) }

--- a/gradle-plugin/src/functionalTest/resources/kotlin-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/kotlin-test/build.gradle.kts
@@ -52,6 +52,14 @@ spine {
     }
 }
 
+configurations.all {
+    resolutionStrategy {
+        force(
+            io.spine.dependency.local.Base.lib,
+        )
+    }
+}
+
 dependencies {
     spineCompiler("io.spine.tools:compiler-test-env:+")
     Protobuf.libs.forEach { implementation(it) }

--- a/gradle-plugin/src/functionalTest/resources/kotlin-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/kotlin-test/build.gradle.kts
@@ -64,9 +64,3 @@ dependencies {
     spineCompiler("io.spine.tools:compiler-test-env:+")
     Protobuf.libs.forEach { implementation(it) }
 }
-
-protobuf {
-    protoc {
-        artifact = io.spine.dependency.lib.Protobuf.compiler
-    }
-}

--- a/gradle-plugin/src/functionalTest/resources/launch-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/launch-test/build.gradle.kts
@@ -55,12 +55,6 @@ dependencies {
     spineCompiler("io.spine.tools:compiler-test-env:+")
 }
 
-protobuf {
-    protoc {
-        artifact = io.spine.dependency.lib.Protobuf.compiler
-    }
-}
-
 spine {
     compiler {
         plugins(

--- a/gradle-plugin/src/functionalTest/resources/launch-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/launch-test/build.gradle.kts
@@ -43,6 +43,14 @@ repositories {
     standardToSpineSdk()
 }
 
+configurations.all {
+    resolutionStrategy {
+        force(
+            io.spine.dependency.local.Base.lib,
+        )
+    }
+}
+
 dependencies {
     spineCompiler("io.spine.tools:compiler-test-env:+")
 }

--- a/gradle-plugin/src/functionalTest/resources/with-functional-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/with-functional-test/build.gradle.kts
@@ -54,6 +54,14 @@ spine {
     }
 }
 
+configurations.all {
+    resolutionStrategy {
+        force(
+            io.spine.dependency.local.Base.lib,
+        )
+    }
+}
+
 dependencies {
     spineCompiler("io.spine.tools:compiler-test-env:+")
     Protobuf.libs.forEach { implementation(it) }

--- a/gradle-plugin/src/functionalTest/resources/with-functional-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/with-functional-test/build.gradle.kts
@@ -67,12 +67,6 @@ dependencies {
     Protobuf.libs.forEach { implementation(it) }
 }
 
-protobuf {
-    protoc {
-        artifact = io.spine.dependency.lib.Protobuf.compiler
-    }
-}
-
 @Suppress("UNUSED_VARIABLE") /* `test` and `functionalTest` variables are really used by their
   names and types for obtaining or creating corresponding suite instances via `by` calls. */
 testing {

--- a/gradle-plugin/src/main/kotlin/io/spine/tools/compiler/gradle/plugin/Plugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/tools/compiler/gradle/plugin/Plugin.kt
@@ -224,7 +224,7 @@ private fun Project.setProtocArtifact() {
         compilerGradlePlugin,
         Plugin::class.java.classLoader
     )
-    val protocArtifact = artifactMeta.dependencies.find(protobufProtocArtifact) as MavenArtifact?
+    val protocArtifact = artifactMeta.dependencies.find(protobufProtocArtifact) as? MavenArtifact
     checkNotNull(protocArtifact) {
         "Unable to load `protoc` dependency of `${Plugin::class.qualifiedName}`."
     }

--- a/gradle-plugin/src/main/kotlin/io/spine/tools/compiler/gradle/plugin/Plugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/tools/compiler/gradle/plugin/Plugin.kt
@@ -229,7 +229,7 @@ private fun Project.setProtocArtifact() {
         Module("com.google.protobuf", "protoc")
     ) as MavenArtifact?
     checkNotNull(protocArtifact) {
-        "Unable to load `protoc` dependency of ${Plugin::class.qualifiedName}"
+        "Unable to load `protoc` dependency of `${Plugin::class.qualifiedName}`."
     }
     protobufExtension!!.protoc { locator ->
         locator.artifact = protocArtifact.coordinates

--- a/gradle-plugin/src/main/kotlin/io/spine/tools/compiler/gradle/plugin/Plugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/tools/compiler/gradle/plugin/Plugin.kt
@@ -51,6 +51,8 @@ import io.spine.tools.compiler.gradle.plugin.GeneratedSubdir.KOTLIN
 import io.spine.tools.compiler.params.WorkingDirectory
 import io.spine.string.toBase64Encoded
 import io.spine.tools.code.SourceSetName
+import io.spine.tools.compiler.gradle.api.Artifacts.compilerBackend
+import io.spine.tools.compiler.gradle.api.Artifacts.protobufProtocArtifact
 import io.spine.tools.gradle.lib.LibraryPlugin
 import io.spine.tools.gradle.lib.spineExtension
 import io.spine.tools.gradle.project.hasJava
@@ -166,7 +168,7 @@ private fun Project.createConfigurations(compilerVersion: String) {
     dependencies.add(artifactConfig.name, cliDependency)
 
     configurations.create(USER_CLASSPATH_CONFIGURATION) {
-        it.exclude(group = Artifacts.group, module = Artifacts.compilerBackend)
+        it.exclude(group = compilerBackend.group, module = compilerBackend.name)
     }
 }
 
@@ -221,17 +223,10 @@ private fun Project.createCleanTask(sourceSet: SourceSet) {
 
 private fun Project.setProtocArtifact() {
     val artifactMeta = ArtifactMeta.loadFromResource(
-        //TODO:2025-09-20:alexander.yevsyukov: It should be `compiler-gradle-plugin`.
-        // We are missing the prefix here which is added by `spinePublishing`.
-        // This should be handled either as a property of `artifactMeta` or
-        // Handling of `artifactMeta` should smell the present of `spinePublishing and
-        // act accordingly.
-        Module("io.spine.tools", "gradle-plugin"),
+        Artifacts.compilerGradlePlugin,
         Plugin::class.java.classLoader
     )
-    val protocArtifact = artifactMeta.dependencies.find(
-        Module("com.google.protobuf", "protoc")
-    ) as MavenArtifact?
+    val protocArtifact = artifactMeta.dependencies.find(protobufProtocArtifact) as MavenArtifact?
     checkNotNull(protocArtifact) {
         "Unable to load `protoc` dependency of `${Plugin::class.qualifiedName}`."
     }

--- a/gradle-plugin/src/main/kotlin/io/spine/tools/compiler/gradle/plugin/Plugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/tools/compiler/gradle/plugin/Plugin.kt
@@ -222,6 +222,10 @@ private fun Project.createCleanTask(sourceSet: SourceSet) {
 private fun Project.setProtocArtifact() {
     val artifactMeta = ArtifactMeta.loadFromResource(
         //TODO:2025-09-20:alexander.yevsyukov: It should be `compiler-gradle-plugin`.
+        // We are missing the prefix here which is added by `spinePublishing`.
+        // This should be handled either as a property of `artifactMeta` or
+        // Handling of `artifactMeta` should smell the present of `spinePublishing and
+        // act accordingly.
         Module("io.spine.tools", "gradle-plugin"),
         Plugin::class.java.classLoader
     )

--- a/gradle-plugin/src/main/kotlin/io/spine/tools/compiler/gradle/plugin/Plugin.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/tools/compiler/gradle/plugin/Plugin.kt
@@ -34,7 +34,12 @@ import com.google.common.collect.ImmutableList
 import com.google.errorprone.annotations.CanIgnoreReturnValue
 import com.google.protobuf.gradle.GenerateProtoTask
 import io.spine.code.proto.DescriptorReference
+import io.spine.string.toBase64Encoded
+import io.spine.tools.code.SourceSetName
 import io.spine.tools.compiler.gradle.api.Artifacts
+import io.spine.tools.compiler.gradle.api.Artifacts.compilerBackend
+import io.spine.tools.compiler.gradle.api.Artifacts.compilerGradlePlugin
+import io.spine.tools.compiler.gradle.api.Artifacts.protobufProtocArtifact
 import io.spine.tools.compiler.gradle.api.CompilerSettings
 import io.spine.tools.compiler.gradle.api.CompilerTask
 import io.spine.tools.compiler.gradle.api.Names.COMPILER_RAW_ARTIFACT
@@ -49,10 +54,6 @@ import io.spine.tools.compiler.gradle.plugin.GeneratedSubdir.GRPC
 import io.spine.tools.compiler.gradle.plugin.GeneratedSubdir.JAVA
 import io.spine.tools.compiler.gradle.plugin.GeneratedSubdir.KOTLIN
 import io.spine.tools.compiler.params.WorkingDirectory
-import io.spine.string.toBase64Encoded
-import io.spine.tools.code.SourceSetName
-import io.spine.tools.compiler.gradle.api.Artifacts.compilerBackend
-import io.spine.tools.compiler.gradle.api.Artifacts.protobufProtocArtifact
 import io.spine.tools.gradle.lib.LibraryPlugin
 import io.spine.tools.gradle.lib.spineExtension
 import io.spine.tools.gradle.project.hasJava
@@ -65,7 +66,6 @@ import io.spine.tools.gradle.task.descriptorSetFile
 import io.spine.tools.gradle.task.findKotlinDirectorySet
 import io.spine.tools.meta.ArtifactMeta
 import io.spine.tools.meta.MavenArtifact
-import io.spine.tools.meta.Module
 import java.io.File
 import java.io.IOException
 import java.nio.file.Path
@@ -83,14 +83,15 @@ import org.gradle.kotlin.dsl.register
  * Adds the `launchSpineCompiler` tasks which runs the executable with the arguments
  * assembled from settings of this plugin.
  *
- * The users can submit configuration parameters, such as renderer and plugin class names, etc. via
- * the `compiler { }` extension.
+ * The users can submit configuration parameters, such as renderer and plugin class
+ * names, etc. via the `compiler { }` extension.
  *
- * The users can submit the user classpath to the Compiler by declaring dependencies using
- * the `spineCompiler` configuration.
+ * The user classpath to the Compiler can be passed by declaring dependencies
+ * using the `spineCompiler` configuration.
  *
- * Example:
- * ```
+ * Example (`build.gradle.kts`):
+ *
+ * ```kotlin
  * spine {
  *     compiler {
  *         plugins("com.acme.MyPlugin")
@@ -139,10 +140,7 @@ public class Plugin : LibraryPlugin<CompilerSettings>(
         @JvmStatic
         @VisibleForTesting
         public fun readVersion(): String {
-            val artifact = ArtifactMeta.loadFromResource(
-                Module("io.spine.tools", "gradle-plugin"),
-                this::class.java
-            )
+            val artifact = ArtifactMeta.loadFromResource(compilerGradlePlugin, this::class.java)
             return artifact.version
         }
     }
@@ -223,7 +221,7 @@ private fun Project.createCleanTask(sourceSet: SourceSet) {
 
 private fun Project.setProtocArtifact() {
     val artifactMeta = ArtifactMeta.loadFromResource(
-        Artifacts.compilerGradlePlugin,
+        compilerGradlePlugin,
         Plugin::class.java.classLoader
     )
     val protocArtifact = artifactMeta.dependencies.find(protobufProtocArtifact) as MavenArtifact?

--- a/pom.xml
+++ b/pom.xml
@@ -140,19 +140,19 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>gradle-plugin-api</artifactId>
-    <version>2.0.0-SNAPSHOT.354</version>
+    <version>2.0.0-SNAPSHOT.355</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>jvm-tools</artifactId>
-    <version>2.0.0-SNAPSHOT.354</version>
+    <version>2.0.0-SNAPSHOT.355</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>plugin-base</artifactId>
-    <version>2.0.0-SNAPSHOT.354</version>
+    <version>2.0.0-SNAPSHOT.355</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -164,13 +164,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>psi-java</artifactId>
-    <version>2.0.0-SNAPSHOT.354</version>
+    <version>2.0.0-SNAPSHOT.355</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>tool-base</artifactId>
-    <version>2.0.0-SNAPSHOT.354</version>
+    <version>2.0.0-SNAPSHOT.355</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -236,7 +236,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>plugin-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.354</version>
+    <version>2.0.0-SNAPSHOT.355</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>spine-compiler</artifactId>
-<version>2.0.0-SNAPSHOT.012</version>
+<version>2.0.0-SNAPSHOT.013</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -140,19 +140,19 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>gradle-plugin-api</artifactId>
-    <version>2.0.0-SNAPSHOT.350</version>
+    <version>2.0.0-SNAPSHOT.353</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>jvm-tools</artifactId>
-    <version>2.0.0-SNAPSHOT.350</version>
+    <version>2.0.0-SNAPSHOT.353</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>plugin-base</artifactId>
-    <version>2.0.0-SNAPSHOT.350</version>
+    <version>2.0.0-SNAPSHOT.353</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -164,13 +164,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>psi-java</artifactId>
-    <version>2.0.0-SNAPSHOT.350</version>
+    <version>2.0.0-SNAPSHOT.353</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>tool-base</artifactId>
-    <version>2.0.0-SNAPSHOT.350</version>
+    <version>2.0.0-SNAPSHOT.353</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -236,7 +236,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>plugin-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.350</version>
+    <version>2.0.0-SNAPSHOT.353</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -140,19 +140,19 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>gradle-plugin-api</artifactId>
-    <version>2.0.0-SNAPSHOT.353</version>
+    <version>2.0.0-SNAPSHOT.354</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>jvm-tools</artifactId>
-    <version>2.0.0-SNAPSHOT.353</version>
+    <version>2.0.0-SNAPSHOT.354</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>plugin-base</artifactId>
-    <version>2.0.0-SNAPSHOT.353</version>
+    <version>2.0.0-SNAPSHOT.354</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -164,13 +164,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>psi-java</artifactId>
-    <version>2.0.0-SNAPSHOT.353</version>
+    <version>2.0.0-SNAPSHOT.354</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>tool-base</artifactId>
-    <version>2.0.0-SNAPSHOT.353</version>
+    <version>2.0.0-SNAPSHOT.354</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -236,7 +236,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>plugin-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.353</version>
+    <version>2.0.0-SNAPSHOT.354</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -32,4 +32,4 @@
  *
  * For dependencies on Spine SDK module please see [io.spine.dependency.local.Spine].
  */
-val compilerVersion: String by extra("2.0.0-SNAPSHOT.012")
+val compilerVersion: String by extra("2.0.0-SNAPSHOT.013")


### PR DESCRIPTION
This PR extends the Compiler so that its Gradle plugin adds the `protoc` artifact when configuring Protobuf Gradle Plugin  in a project. 

This is what McJava used to do. Without this feature it is needed to configure the `protobuf / protoc / artifact` property in a project to which the Compiler plugin is applied. The user still will be able to overwrite the artifact in an unlikely case of such a need.
