### PR TITLE
Add custom publishing destinations

### DIFF
--- a/.agents/project-structure-expectations.md
+++ b/.agents/project-structure-expectations.md
@@ -16,6 +16,6 @@ buildSrc/
 build.gradle.kts # Kotlin-based build configuration
 settings.gradle.kts # Project structure and settings
 README.md # Project overview
-AGENTS.md # LLM agent instructions (this file)
+AGENTS.md # Entry point for LLM agent instructions
 version.gradle.kts # Declares the project version. 
 ```

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -255,18 +255,6 @@
       <option name="m_limit" value="20" />
     </inspection_tool>
     <inspection_tool class="FieldMayBeStatic" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="FieldNamingConvention" enabled="true" level="WARNING" enabled_by_default="true">
-      <extension name="ConstantNamingConvention" enabled="false">
-        <option name="m_regex" value="[A-Z_\d]*" />
-        <option name="m_minLength" value="5" />
-        <option name="m_maxLength" value="32" />
-      </extension>
-      <extension name="InstanceVariableNamingConvention" enabled="true">
-        <option name="m_regex" value="[a-z][A-Za-z\d]*" />
-        <option name="m_minLength" value="2" />
-        <option name="m_maxLength" value="32" />
-      </extension>
-    </inspection_tool>
     <inspection_tool class="FloatingPointEquality" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ForLoopReplaceableByWhile" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_ignoreLoopsWithoutConditions" value="false" />

--- a/buildSrc/src/main/kotlin/io/spine/gradle/protobuf/ProtoTaskExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/protobuf/ProtoTaskExtensions.kt
@@ -109,9 +109,7 @@ private fun GenerateProtoTask.generatedDir(language: String = ""): File {
 fun GenerateProtoTask.setup() {
     builtins.maybeCreate("kotlin")
     setupDescriptorSetFileCreation()
-    doFirst {
-        excludeProtocOutput()
-    }
+    excludeProtocOutput()
     doLast {
         copyGeneratedFiles()
     }
@@ -231,21 +229,34 @@ private fun GenerateProtoTask.deleteComGoogle(language: String) {
  */
 fun GenerateProtoTask.excludeProtocOutput() {
     val protocOutputDir = File(outputBaseDir).parentFile
+
+    /**
+     * Filter out directories belonging to `build/generated/source/proto`.
+     */
+    fun filterFor(directorySet: SourceDirectorySet) {
+        val newSourceDirectories = directorySet.sourceDirectories
+            .filter { !it.residesIn(protocOutputDir) }
+            .toSet()
+        // Make sure we start from scratch.
+        // Not doing this failed the following, real, assignment sometimes.
+        directorySet.setSrcDirs(listOf<String>())
+        directorySet.srcDirs(newSourceDirectories)
+    }
+
     val java: SourceDirectorySet = sourceSet.java
-
-    // Filter out directories belonging to `build/generated/source/proto`.
-    val newSourceDirectories = java.sourceDirectories
-        .filter { !it.residesIn(protocOutputDir) }
-        .toSet()
-    // Make sure we start from scratch.
-    // Not doing this failed the following, real, assignment sometimes.
-    java.setSrcDirs(listOf<String>())
-    java.srcDirs(newSourceDirectories)
-
+    filterFor(java)
     // Add copied files to the Java source set.
     java.srcDir(generatedDir("java"))
-    java.srcDir(generatedDir("kotlin"))
+
+    val kotlin = sourceSet.kotlin
+    filterFor(kotlin)
+    // Add copied files to the Kotlin source set.
+    kotlin.srcDir(generatedDir("kotlin"))
 }
+
+private val SourceSet.kotlin: SourceDirectorySet get() =
+    (this as org.gradle.api.plugins.ExtensionAware).extensions.getByName("kotlin")
+            as SourceDirectorySet
 
 /**
  * Make sure Kotlin compilation explicitly depends on this `GenerateProtoTask` to avoid racing.

--- a/buildSrc/src/main/kotlin/kmp-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/kmp-module.gradle.kts
@@ -143,7 +143,6 @@ java {
     targetCompatibility = BuildSettings.javaVersionCompat
 }
 
-
 /**
  * Performs the standard task's configuration.
  *

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:compiler-api:2.0.0-SNAPSHOT.013`
+# Dependencies of `io.spine.tools:compiler-api:2.0.0-SNAPSHOT.014`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -1098,14 +1098,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using 
+This report was generated on **Wed Sep 24 16:01:41 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-api-tests:2.0.0-SNAPSHOT.013`
+# Dependencies of `io.spine.tools:compiler-api-tests:2.0.0-SNAPSHOT.014`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1916,14 +1916,14 @@ This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using 
+This report was generated on **Wed Sep 24 16:01:41 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-backend:2.0.0-SNAPSHOT.013`
+# Dependencies of `io.spine.tools:compiler-backend:2.0.0-SNAPSHOT.014`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -3021,14 +3021,14 @@ This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using 
+This report was generated on **Wed Sep 24 16:01:41 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-cli:2.0.0-SNAPSHOT.013`
+# Dependencies of `io.spine.tools:compiler-cli:2.0.0-SNAPSHOT.014`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -4150,14 +4150,14 @@ This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using 
+This report was generated on **Wed Sep 24 16:01:41 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-gradle-api:2.0.0-SNAPSHOT.013`
+# Dependencies of `io.spine.tools:compiler-gradle-api:2.0.0-SNAPSHOT.014`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -5190,14 +5190,14 @@ This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using 
+This report was generated on **Wed Sep 24 16:01:41 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-gradle-plugin:2.0.0-SNAPSHOT.013`
+# Dependencies of `io.spine.tools:compiler-gradle-plugin:2.0.0-SNAPSHOT.014`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -6278,14 +6278,14 @@ This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using 
+This report was generated on **Wed Sep 24 16:01:50 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-jvm:2.0.0-SNAPSHOT.013`
+# Dependencies of `io.spine.tools:compiler-jvm:2.0.0-SNAPSHOT.014`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -7383,14 +7383,14 @@ This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using 
+This report was generated on **Wed Sep 24 16:01:41 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-params:2.0.0-SNAPSHOT.013`
+# Dependencies of `io.spine.tools:compiler-params:2.0.0-SNAPSHOT.014`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -8480,14 +8480,14 @@ This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using 
+This report was generated on **Wed Sep 24 16:01:41 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-protoc-plugin:2.0.0-SNAPSHOT.013`
+# Dependencies of `io.spine.tools:compiler-protoc-plugin:2.0.0-SNAPSHOT.014`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9296,14 +9296,14 @@ This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using 
+This report was generated on **Wed Sep 24 16:01:41 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-test-env:2.0.0-SNAPSHOT.013`
+# Dependencies of `io.spine.tools:compiler-test-env:2.0.0-SNAPSHOT.014`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -10397,14 +10397,14 @@ This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using 
+This report was generated on **Wed Sep 24 16:01:41 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-testlib:2.0.0-SNAPSHOT.013`
+# Dependencies of `io.spine.tools:compiler-testlib:2.0.0-SNAPSHOT.014`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -11605,6 +11605,6 @@ This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Sep 20 15:11:25 WEST 2025** using 
+This report was generated on **Wed Sep 24 16:01:41 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -30,6 +30,8 @@ import io.spine.dependency.local.TestLib
 import io.spine.dependency.local.ToolBase
 import io.spine.dependency.test.JUnit
 import io.spine.gradle.isSnapshot
+import io.spine.gradle.publish.PublishingRepos.cloudArtifactRegistry
+import io.spine.gradle.publish.PublishingRepos.gitHub
 
 plugins {
     module
@@ -146,6 +148,8 @@ val publish: Task by tasks.getting {
 publishing {
     repositories {
         mavenLocal()
+        gitHub("compiler")
+        cloudArtifactRegistry
         if (isSnapshot) {
             remove(gradlePluginPortal())
         }
@@ -165,8 +169,7 @@ gradlePlugin {
             id = "io.spine.compiler"
             implementationClass = "io.spine.tools.compiler.gradle.plugin.Plugin"
             displayName = "Spine Compiler Gradle Plugin"
-            description =
-                "Sets up the Spine Compiler to be used in your project."
+            description = "Sets up the Spine Compiler to be used in your project."
             tags.set(listOf("spine", "ddd", "protobuf", "compiler", "code-generation", "codegen"))
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>spine-compiler</artifactId>
-<version>2.0.0-SNAPSHOT.013</version>
+<version>2.0.0-SNAPSHOT.014</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -25,7 +25,7 @@
  */
 
 /**
- * The version of the Spine Compiler to built by this project.
+ * The version of the Spine Compiler to be built by this project.
  *
  * This version is also used by integration test projects.
  * E.g. see `tests/consumer/build.gradle.kts`.

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -25,11 +25,15 @@
  */
 
 /**
- * The version of the Spine Compiler to publish.
+ * The version of the Spine Compiler to built by this project.
  *
- * This version also used by integration test projects.
+ * This version is also used by integration test projects.
  * E.g. see `tests/consumer/build.gradle.kts`.
- *
- * For dependencies on Spine SDK module please see [io.spine.dependency.local.Spine].
  */
-val compilerVersion: String by extra("2.0.0-SNAPSHOT.013")
+val compilerVersion: String by extra("2.0.0-SNAPSHOT.014")
+
+/**
+ * The version, same as [compilerVersion], which is used for publishing
+ * the Compiler Maven artifacts.
+ */
+val versionToPublish by extra(compilerVersion)


### PR DESCRIPTION
This PR adds our custom Maven repositories as destinations for the publishing the Compiler Gradle Plugin. Previously, the destination was only Gradle Plugin Portal.

`config` was also updated.
