### PR TITLE
Remove repeated version loading in tests

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:compiler-api:2.0.0-SNAPSHOT.018`
+# Dependencies of `io.spine.tools:compiler-api:2.0.0-SNAPSHOT.019`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -1098,14 +1098,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 30 22:47:46 WEST 2025** using 
+This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-api-tests:2.0.0-SNAPSHOT.018`
+# Dependencies of `io.spine.tools:compiler-api-tests:2.0.0-SNAPSHOT.019`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1916,14 +1916,14 @@ This report was generated on **Tue Sep 30 22:47:46 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 30 22:47:46 WEST 2025** using 
+This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-backend:2.0.0-SNAPSHOT.018`
+# Dependencies of `io.spine.tools:compiler-backend:2.0.0-SNAPSHOT.019`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -3021,14 +3021,14 @@ This report was generated on **Tue Sep 30 22:47:46 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 30 22:47:46 WEST 2025** using 
+This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-cli:2.0.0-SNAPSHOT.018`
+# Dependencies of `io.spine.tools:compiler-cli:2.0.0-SNAPSHOT.019`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -4184,14 +4184,14 @@ This report was generated on **Tue Sep 30 22:47:46 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 30 22:47:46 WEST 2025** using 
+This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-gradle-api:2.0.0-SNAPSHOT.018`
+# Dependencies of `io.spine.tools:compiler-gradle-api:2.0.0-SNAPSHOT.019`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -5224,14 +5224,14 @@ This report was generated on **Tue Sep 30 22:47:46 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 30 22:47:46 WEST 2025** using 
+This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-gradle-plugin:2.0.0-SNAPSHOT.018`
+# Dependencies of `io.spine.tools:compiler-gradle-plugin:2.0.0-SNAPSHOT.019`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -6312,14 +6312,14 @@ This report was generated on **Tue Sep 30 22:47:46 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 30 22:47:46 WEST 2025** using 
+This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-jvm:2.0.0-SNAPSHOT.018`
+# Dependencies of `io.spine.tools:compiler-jvm:2.0.0-SNAPSHOT.019`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -7451,14 +7451,14 @@ This report was generated on **Tue Sep 30 22:47:46 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 30 22:47:46 WEST 2025** using 
+This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-params:2.0.0-SNAPSHOT.018`
+# Dependencies of `io.spine.tools:compiler-params:2.0.0-SNAPSHOT.019`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -8548,14 +8548,14 @@ This report was generated on **Tue Sep 30 22:47:46 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 30 22:47:46 WEST 2025** using 
+This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-protoc-plugin:2.0.0-SNAPSHOT.018`
+# Dependencies of `io.spine.tools:compiler-protoc-plugin:2.0.0-SNAPSHOT.019`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9364,14 +9364,14 @@ This report was generated on **Tue Sep 30 22:47:46 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 30 22:47:46 WEST 2025** using 
+This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-test-env:2.0.0-SNAPSHOT.018`
+# Dependencies of `io.spine.tools:compiler-test-env:2.0.0-SNAPSHOT.019`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -10465,14 +10465,14 @@ This report was generated on **Tue Sep 30 22:47:46 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 30 22:47:46 WEST 2025** using 
+This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-testlib:2.0.0-SNAPSHOT.018`
+# Dependencies of `io.spine.tools:compiler-testlib:2.0.0-SNAPSHOT.019`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -11673,6 +11673,6 @@ This report was generated on **Tue Sep 30 22:47:46 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 30 22:47:46 WEST 2025** using 
+This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/gradle-plugin/src/functionalTest/kotlin/io/spine/tools/compiler/gradle/plugin/PluginSpec.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/io/spine/tools/compiler/gradle/plugin/PluginSpec.kt
@@ -76,36 +76,12 @@ class PluginSpec {
         generatedKotlinDir  = generatedMainDir.resolve("kotlin")
     }
 
-    /**
-     * This function reads the version from resource of the [Plugin] class.
-     *
-     * We experience [java.util.zip.ZipException] recently when running these tests.
-     * This function attempts to repeat the tries with the hope that the original cause
-     * of the error is concurrency in reading/writing operations for the production code JAR.
-     */
-    private fun readVersionWithRetry(): String {
-        var lastException: Exception? = null
-        val retries = 10
-        repeat(retries) { attempt ->
-            try {
-                return Plugin.version
-            } catch (e: Exception) {
-                lastException = e
-                if (attempt < retries - 1) {
-                    Thread.sleep(1000)
-                }
-            }
-        }
-        throw lastException!!
-    }
-
     private fun createProject(resourceDir: String) {
-        val version = readVersionWithRetry()
         val builder = GradleProject.setupAt(projectDir)
             .fromResources(resourceDir)
             .withSharedTestKitDirectory()
             .replace("@COMPILER_PLUGIN_ID@", GRADLE_PLUGIN_ID)
-            .replace("@COMPILER_VERSION@", version)
+            .replace("@COMPILER_VERSION@", Plugin.version)
             .withLoggingLevel(LogLevel.INFO)
             /* Uncomment the following if you need to debug the build process.
                Please note that:

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>spine-compiler</artifactId>
-<version>2.0.0-SNAPSHOT.018</version>
+<version>2.0.0-SNAPSHOT.019</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -30,7 +30,7 @@
  * This version is also used by integration test projects.
  * E.g. see `tests/consumer/build.gradle.kts`.
  */
-val compilerVersion: String by extra("2.0.0-SNAPSHOT.018")
+val compilerVersion: String by extra("2.0.0-SNAPSHOT.019")
 
 /**
  * The version, same as [compilerVersion], which is used for publishing


### PR DESCRIPTION
This PR removes the test arrangement for retrying loading the version of the Compiler Gradle plugin.

The hope is that the new way for obtaining the version introduced in the previous PR is more reliable and does not require repeated attempts in tests.
