### PR TITLE
Open `javac` to Palantir Java Formatter

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
@@ -70,7 +70,7 @@ object Compiler {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "2.0.0-SNAPSHOT.017"
+    private const val fallbackVersion = "2.0.0-SNAPSHOT.019"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -79,7 +79,7 @@ object Compiler {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "2.0.0-SNAPSHOT.017"
+    private const val fallbackDfVersion = "2.0.0-SNAPSHOT.019"
 
     /**
      * The artifact for the ProtoData Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -34,7 +34,7 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object ToolBase {
     const val group = Spine.toolsGroup
-    const val version = "2.0.0-SNAPSHOT.357"
+    const val version = "2.0.0-SNAPSHOT.358"
 
     const val lib = "$group:tool-base:$version"
     const val pluginBase = "$group:plugin-base:$version"

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:compiler-api:2.0.0-SNAPSHOT.019`
+# Dependencies of `io.spine.tools:compiler-api:2.0.0-SNAPSHOT.020`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -1098,14 +1098,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using 
+This report was generated on **Wed Oct 01 19:43:08 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-api-tests:2.0.0-SNAPSHOT.019`
+# Dependencies of `io.spine.tools:compiler-api-tests:2.0.0-SNAPSHOT.020`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1916,14 +1916,14 @@ This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using 
+This report was generated on **Wed Oct 01 19:43:08 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-backend:2.0.0-SNAPSHOT.019`
+# Dependencies of `io.spine.tools:compiler-backend:2.0.0-SNAPSHOT.020`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -3021,14 +3021,14 @@ This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using 
+This report was generated on **Wed Oct 01 19:43:08 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-cli:2.0.0-SNAPSHOT.019`
+# Dependencies of `io.spine.tools:compiler-cli:2.0.0-SNAPSHOT.020`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -4184,14 +4184,14 @@ This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using 
+This report was generated on **Wed Oct 01 19:43:08 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-gradle-api:2.0.0-SNAPSHOT.019`
+# Dependencies of `io.spine.tools:compiler-gradle-api:2.0.0-SNAPSHOT.020`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -5224,14 +5224,14 @@ This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using 
+This report was generated on **Wed Oct 01 19:43:08 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-gradle-plugin:2.0.0-SNAPSHOT.019`
+# Dependencies of `io.spine.tools:compiler-gradle-plugin:2.0.0-SNAPSHOT.020`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -6312,14 +6312,14 @@ This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using 
+This report was generated on **Wed Oct 01 19:43:08 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-jvm:2.0.0-SNAPSHOT.019`
+# Dependencies of `io.spine.tools:compiler-jvm:2.0.0-SNAPSHOT.020`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -7451,14 +7451,14 @@ This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using 
+This report was generated on **Wed Oct 01 19:43:08 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-params:2.0.0-SNAPSHOT.019`
+# Dependencies of `io.spine.tools:compiler-params:2.0.0-SNAPSHOT.020`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -8548,14 +8548,14 @@ This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using 
+This report was generated on **Wed Oct 01 19:43:08 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-protoc-plugin:2.0.0-SNAPSHOT.019`
+# Dependencies of `io.spine.tools:compiler-protoc-plugin:2.0.0-SNAPSHOT.020`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9364,14 +9364,14 @@ This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using 
+This report was generated on **Wed Oct 01 19:43:08 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-test-env:2.0.0-SNAPSHOT.019`
+# Dependencies of `io.spine.tools:compiler-test-env:2.0.0-SNAPSHOT.020`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -10465,14 +10465,14 @@ This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using 
+This report was generated on **Wed Oct 01 19:43:08 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-testlib:2.0.0-SNAPSHOT.019`
+# Dependencies of `io.spine.tools:compiler-testlib:2.0.0-SNAPSHOT.020`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -11673,6 +11673,6 @@ This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Sep 30 23:51:20 WEST 2025** using 
+This report was generated on **Wed Oct 01 19:43:08 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/gradle-plugin/src/main/kotlin/io/spine/tools/compiler/gradle/plugin/LaunchSpineCompiler.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/tools/compiler/gradle/plugin/LaunchSpineCompiler.kt
@@ -110,6 +110,16 @@ public abstract class LaunchSpineCompiler : JavaExec() {
         WorkingDirectory(dir.toPath())
     }
 
+    init {
+        jvmArgs(
+            // Open access for Palantir Java Formatter.
+            "--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+            "--add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+            "--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+            "--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+        )
+    }
+
     /**
      * Configures the CLI command for this task.
      *

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>spine-compiler</artifactId>
-<version>2.0.0-SNAPSHOT.019</version>
+<version>2.0.0-SNAPSHOT.020</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -146,19 +146,19 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>gradle-plugin-api</artifactId>
-    <version>2.0.0-SNAPSHOT.357</version>
+    <version>2.0.0-SNAPSHOT.358</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>jvm-tools</artifactId>
-    <version>2.0.0-SNAPSHOT.357</version>
+    <version>2.0.0-SNAPSHOT.358</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>plugin-base</artifactId>
-    <version>2.0.0-SNAPSHOT.357</version>
+    <version>2.0.0-SNAPSHOT.358</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -170,13 +170,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>psi-java</artifactId>
-    <version>2.0.0-SNAPSHOT.357</version>
+    <version>2.0.0-SNAPSHOT.358</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>tool-base</artifactId>
-    <version>2.0.0-SNAPSHOT.357</version>
+    <version>2.0.0-SNAPSHOT.358</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -242,7 +242,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>plugin-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.357</version>
+    <version>2.0.0-SNAPSHOT.358</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -33,6 +33,7 @@ import io.spine.dependency.lib.KotlinPoet
 import io.spine.dependency.lib.Protobuf
 import io.spine.dependency.local.Base
 import io.spine.dependency.local.CoreJvm
+import io.spine.dependency.local.Compiler
 import io.spine.dependency.local.Logging
 import io.spine.dependency.local.Reflect
 import io.spine.dependency.local.ToolBase
@@ -112,6 +113,9 @@ subprojects {
                     ToolBase.jvmTools,
                     ToolBase.pluginBase,
                     ToolBase.gradlePluginApi,
+                    Compiler.api,
+                    Compiler.params,
+                    Compiler.gradleApi,
                     Validation.runtime,
                     Logging.lib,
                     Logging.grpcContext,

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -30,7 +30,7 @@
  * This version is also used by integration test projects.
  * E.g. see `tests/consumer/build.gradle.kts`.
  */
-val compilerVersion: String by extra("2.0.0-SNAPSHOT.019")
+val compilerVersion: String by extra("2.0.0-SNAPSHOT.020")
 
 /**
  * The version, same as [compilerVersion], which is used for publishing


### PR DESCRIPTION
This PR updates the code so it passes necessary flags to `LaunchSpineCompiler` Gradle tasks so that Palantir Java Formatter can work with hidden `javac` API.