### PR TITLE
Avoid Intellij Platform dependencies in Gradle Plugin

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -44,7 +44,8 @@ object ToolBase {
     const val intellijPlatformJava = "$group:intellij-platform-java:$version"
 
     const val psi = "$group:psi:$version"
-    const val psiJava = "$group:psi-java:$version"
+    const val psiJavaArtifactName = "psi-java"
+    const val psiJava = "$group:$psiJavaArtifactName:$version"
 
     const val gradleRootPlugin = "$group:gradle-root-plugin:$version"
     const val gradlePluginApi = "$group:gradle-plugin-api:$version"

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:compiler-api:2.0.0-SNAPSHOT.023`
+# Dependencies of `io.spine.tools:compiler-api:2.0.0-SNAPSHOT.024`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -1095,14 +1095,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 03 18:25:00 WEST 2025** using 
+This report was generated on **Tue Oct 07 17:56:39 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-api-tests:2.0.0-SNAPSHOT.023`
+# Dependencies of `io.spine.tools:compiler-api-tests:2.0.0-SNAPSHOT.024`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
@@ -1901,14 +1901,14 @@ This report was generated on **Fri Oct 03 18:25:00 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 03 18:25:00 WEST 2025** using 
+This report was generated on **Tue Oct 07 17:56:39 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-backend:2.0.0-SNAPSHOT.023`
+# Dependencies of `io.spine.tools:compiler-backend:2.0.0-SNAPSHOT.024`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -3003,14 +3003,14 @@ This report was generated on **Fri Oct 03 18:25:00 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 03 18:25:00 WEST 2025** using 
+This report was generated on **Tue Oct 07 17:56:39 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-cli:2.0.0-SNAPSHOT.023`
+# Dependencies of `io.spine.tools:compiler-cli:2.0.0-SNAPSHOT.024`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -4146,14 +4146,14 @@ This report was generated on **Fri Oct 03 18:25:00 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 03 18:25:00 WEST 2025** using 
+This report was generated on **Tue Oct 07 17:56:39 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-gradle-api:2.0.0-SNAPSHOT.023`
+# Dependencies of `io.spine.tools:compiler-gradle-api:2.0.0-SNAPSHOT.024`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -5162,14 +5162,14 @@ This report was generated on **Fri Oct 03 18:25:00 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 03 18:25:00 WEST 2025** using 
+This report was generated on **Tue Oct 07 17:56:39 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-gradle-plugin:2.0.0-SNAPSHOT.023`
+# Dependencies of `io.spine.tools:compiler-gradle-plugin:2.0.0-SNAPSHOT.024`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -6226,14 +6226,14 @@ This report was generated on **Fri Oct 03 18:25:00 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 03 18:25:00 WEST 2025** using 
+This report was generated on **Tue Oct 07 17:56:39 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-jvm:2.0.0-SNAPSHOT.023`
+# Dependencies of `io.spine.tools:compiler-jvm:2.0.0-SNAPSHOT.024`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -7345,14 +7345,14 @@ This report was generated on **Fri Oct 03 18:25:00 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 03 18:25:00 WEST 2025** using 
+This report was generated on **Tue Oct 07 17:56:39 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-params:2.0.0-SNAPSHOT.023`
+# Dependencies of `io.spine.tools:compiler-params:2.0.0-SNAPSHOT.024`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -8439,14 +8439,14 @@ This report was generated on **Fri Oct 03 18:25:00 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 03 18:25:00 WEST 2025** using 
+This report was generated on **Tue Oct 07 17:56:39 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-protoc-plugin:2.0.0-SNAPSHOT.023`
+# Dependencies of `io.spine.tools:compiler-protoc-plugin:2.0.0-SNAPSHOT.024`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9255,14 +9255,14 @@ This report was generated on **Fri Oct 03 18:25:00 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 03 18:25:00 WEST 2025** using 
+This report was generated on **Tue Oct 07 17:56:39 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-test-env:2.0.0-SNAPSHOT.023`
+# Dependencies of `io.spine.tools:compiler-test-env:2.0.0-SNAPSHOT.024`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -10353,14 +10353,14 @@ This report was generated on **Fri Oct 03 18:25:00 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 03 18:25:00 WEST 2025** using 
+This report was generated on **Tue Oct 07 17:56:39 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-testlib:2.0.0-SNAPSHOT.023`
+# Dependencies of `io.spine.tools:compiler-testlib:2.0.0-SNAPSHOT.024`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.20.0.
@@ -11558,6 +11558,6 @@ This report was generated on **Fri Oct 03 18:25:00 WEST 2025** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 03 18:25:00 WEST 2025** using 
+This report was generated on **Tue Oct 07 17:56:39 WEST 2025** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -26,6 +26,7 @@
 
 import io.spine.dependency.lib.Kotlin
 import io.spine.dependency.lib.Protobuf
+import io.spine.dependency.local.Spine
 import io.spine.dependency.local.TestLib
 import io.spine.dependency.local.ToolBase
 import io.spine.dependency.test.JUnit
@@ -107,7 +108,9 @@ dependencies {
     api(project(":gradle-api"))
     api(ToolBase.gradlePluginApi)
 
-    implementation(project(":api"))
+    implementation(project(":api")) {
+        exclude(group = Spine.toolsGroup, module = ToolBase.psiJavaArtifactName)
+    }
     implementation(project(":params"))
     implementation(ToolBase.lib)
     implementation(ToolBase.jvmTools)

--- a/gradle-plugin/src/main/kotlin/io/spine/tools/compiler/gradle/plugin/LaunchSpineCompiler.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/tools/compiler/gradle/plugin/LaunchSpineCompiler.kt
@@ -163,7 +163,7 @@ public abstract class LaunchSpineCompiler : JavaExec() {
                     // Do not clean directories if we are overwriting files in
                     // the directories created by `protoc`.
                     // Such a mode is deprecated currently, but we may revisit this later.
-                    !Files.isSameFile(s.toPath(), t.toPath())
+                    !(s.exists() && t.exists() && Files.isSameFile(s.toPath(), t.toPath()))
                 }
                 .map { it.second }
                 .filter { it.exists() && it.list()?.isNotEmpty() ?: false }

--- a/gradle-plugin/src/main/kotlin/io/spine/tools/compiler/gradle/plugin/LaunchSpineCompiler.kt
+++ b/gradle-plugin/src/main/kotlin/io/spine/tools/compiler/gradle/plugin/LaunchSpineCompiler.kt
@@ -27,24 +27,24 @@
 package io.spine.tools.compiler.gradle.plugin
 
 import com.google.protobuf.gradle.GenerateProtoTask
-import com.intellij.openapi.util.io.FileUtil
+import io.spine.tools.code.SourceSetName
 import io.spine.tools.compiler.Constants.CLI_APP_CLASS
 import io.spine.tools.compiler.ast.toAbsoluteFile
 import io.spine.tools.compiler.ast.toDirectory
 import io.spine.tools.compiler.gradle.api.Names.COMPILER_RAW_ARTIFACT
 import io.spine.tools.compiler.gradle.api.Names.USER_CLASSPATH_CONFIGURATION
+import io.spine.tools.compiler.gradle.api.compilerWorkingDir
 import io.spine.tools.compiler.gradle.api.error
 import io.spine.tools.compiler.gradle.api.info
-import io.spine.tools.compiler.gradle.api.compilerWorkingDir
 import io.spine.tools.compiler.params.ParametersFileParam
 import io.spine.tools.compiler.params.WorkingDirectory
 import io.spine.tools.compiler.params.pipelineParameters
-import io.spine.tools.code.SourceSetName
 import io.spine.tools.gradle.project.findJavaCompileFor
 import io.spine.tools.gradle.project.findKotlinCompileFor
 import io.spine.tools.gradle.protobuf.containsProtoFiles
 import java.io.File
 import java.io.File.pathSeparator
+import java.nio.file.Files
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -163,7 +163,7 @@ public abstract class LaunchSpineCompiler : JavaExec() {
                     // Do not clean directories if we are overwriting files in
                     // the directories created by `protoc`.
                     // Such a mode is deprecated currently, but we may revisit this later.
-                    !FileUtil.filesEqual(s, t) /* Honor case-sensitivity under macOS. */
+                    !Files.isSameFile(s.toPath(), t.toPath())
                 }
                 .map { it.second }
                 .filter { it.exists() && it.list()?.isNotEmpty() ?: false }

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>spine-compiler</artifactId>
-<version>2.0.0-SNAPSHOT.023</version>
+<version>2.0.0-SNAPSHOT.024</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -30,7 +30,7 @@
  * This version is also used by integration test projects.
  * E.g. see `tests/consumer/build.gradle.kts`.
  */
-val compilerVersion: String by extra("2.0.0-SNAPSHOT.023")
+val compilerVersion: String by extra("2.0.0-SNAPSHOT.024")
 
 /**
  * The version, same as [compilerVersion], which is used for publishing


### PR DESCRIPTION
This PR adjusts the dependencies of the `gradle-plugin` module so that it does not expose IntelliJ Platform fat JARs as its implementation dependencies. These artifacts are transitive dependencies via the `api` module, but the Gradle Plugin module does not, and should not, use any PSI API.

After the code of the `LaunchSpineCompiler` was adjusted to avoid the call to `com.intellij.openapi.util.io.FileUtil`, the `gradle-plugin` module does not depend on the IntelliJ platform.
