### PR TITLE
Fix `tests` build script compilation in CI

### DIFF
--- a/.agents/tasks/fix-tests-build-script-classpath.md
+++ b/.agents/tasks/fix-tests-build-script-classpath.md
@@ -1,0 +1,65 @@
+---
+slug: fix-tests-build-script-classpath
+branch: claude/adoring-tesla-1cff28
+owner: claude
+status: in-progress
+started: 2026-06-09
+---
+
+## Goal
+
+PR #66 CI is green again on both Ubuntu and Windows: the nested `tests`
+build compiles its `build.gradle.kts` instead of failing with
+`Unresolved reference 'Protobuf'` / `'Kotlin'` (Ubuntu + Windows) or
+`Unresolved reference 'io'` (Windows before commit `e8fa227`).
+
+## Context
+
+- The Kotlin DSL extracts the `buildscript {}` block and compiles it as a
+  separate "stage 1" program **without the file-level `import` statements**.
+  Reproduced in isolation with Gradle 9.5.1: short names fail, fully
+  qualified names compile. All other `buildscript` blocks in the repo
+  already use fully qualified names for this reason.
+- Commit `e8fa227` (copilot-swe-agent) replaced the fully qualified names in
+  `tests/build.gradle.kts` with imported short names, breaking script
+  compilation on **all** platforms.
+- The original Windows-only failure (`Unresolved reference 'io'`, run
+  27230621848) has a different cause: the updated Windows workflow sets
+  `git config --global core.symlinks false`, so the `tests/buildSrc ->
+  ../buildSrc` symlink is checked out as a plain text file. The nested
+  build launched by `integrationTest` then has no `buildSrc` at all, and
+  no `io.spine.dependency.*` classes on the script classpath.
+  (`tests/gradle.properties` degrades the same way.)
+
+## Plan
+
+- [x] Diagnose Ubuntu failure (stage-1 imports) and Windows failure
+      (symlink checked out as text file).
+- [x] Revert `e8fa227`: restore fully qualified names in the
+      `buildscript {}` block of `tests/build.gradle.kts`; document why
+      the qualifiers must stay.
+- [x] In root `build.gradle.kts`, make `integrationTest` materialize
+      `tests/buildSrc` and `tests/gradle.properties` as real copies when
+      the symlinks were checked out as placeholder text files.
+- [x] Re-enable Git symlinks on Windows CI (`core.symlinks true`):
+      the symlinked `tests/buildSrc` layout was green on Windows for
+      ~3 years (symlink since 2023-02; `.agents` links since 2025-09;
+      last green Windows run 2026-03-12) until this branch's `config`
+      update introduced `core.symlinks false`. The materialization in
+      root `build.gradle.kts` stays as a no-op fallback for
+      symlink-less checkouts (and for future `config` syncs that may
+      reintroduce the setting; the upstream fix belongs in `config`).
+- [x] Sanity-check what is verifiable locally; commit, push, draft PR
+      into `update-dependencies`.
+- [ ] Confirm both CI jobs are green on PR #66 after the fix lands.
+
+## Log
+
+- 2026-06-09 — diagnosed both failures; synthetic repro of the stage-1
+  import limitation under Gradle 9.5.1 (`/tmp/k1`): short name fails,
+  FQN passes.
+- 2026-06-09 — `materializeTestsLink` verified in the synthetic project:
+  placeholder files are replaced by real copies (`build/`, `.gradle/`
+  excluded); healthy symlinks and already-materialized dirs are left
+  untouched. Full local build not possible: the sandbox network policy
+  blocks Spine repositories (403).

--- a/.github/workflows/build-on-windows.yml
+++ b/.github/workflows/build-on-windows.yml
@@ -8,13 +8,16 @@ jobs:
     name: Build on Windows
 
     steps:
-      - name: Configure Git for Windows symlink compatibility
+      - name: Enable symlinks in Git for Windows
         shell: pwsh
         run: |
-          # Avoid creating/expecting native symlinks on Windows runners.
-          # This helps when repository paths (like .agents/guidelines) are represented
-          # via links that can trigger EPERM on stat/access.
-          git config --global core.symlinks false
+          # The build under `tests` shares `buildSrc`, the Gradle wrapper files,
+          # and `gradle.properties` with the root project via relative symlinks.
+          # With `core.symlinks=false` these links are checked out as plain text
+          # files, and the nested build launched by `integrationTest` fails to
+          # compile its build scripts. GitHub-hosted Windows runners execute
+          # with administrative rights, so Git can create native symlinks.
+          git config --global core.symlinks true
 
       - uses: actions/checkout@v6
         with:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,7 @@ import io.spine.gradle.repo.standardToSpineSdk
 import io.spine.gradle.report.coverage.KoverConfig
 import io.spine.gradle.report.license.LicenseReporter
 import io.spine.gradle.report.pom.PomGenerator
+import java.nio.file.Files
 
 buildscript {
     standardSpineSdkRepositories()
@@ -144,6 +145,42 @@ val localPublish by tasks.registering {
 }
 
 /**
+ * Replaces `tests/<linkName>` with a real copy of the root `<linkName>` if
+ * the symlink did not survive the checkout.
+ *
+ * The build under `tests` shares `buildSrc` and `gradle.properties` with this
+ * project via relative symlinks. When the repository is checked out without
+ * symlink support (e.g., Git with `core.symlinks=false` under Windows), each
+ * link turns into a plain text file containing the link target (e.g.,
+ * `../buildSrc`). The nested build launched by `integrationTest` then has no
+ * `buildSrc` and fails to compile its build scripts with "Unresolved
+ * reference" errors. Restoring the linked content keeps the integration tests
+ * independent of the symlink handling of the checkout.
+ */
+fun materializeTestsLink(linkName: String) {
+    val link = file("tests/$linkName")
+    if (Files.isSymbolicLink(link.toPath())) {
+        return
+    }
+    val placeholder = link.isFile && link.readText().trim() == "../$linkName"
+    if (!placeholder) {
+        return
+    }
+    link.delete()
+    val target = file(linkName)
+    if (target.isDirectory) {
+        copy {
+            from(target) {
+                exclude("build", "build/**", ".gradle", ".gradle/**")
+            }
+            into(link)
+        }
+    } else {
+        target.copyTo(link)
+    }
+}
+
+/**
  * The `integrationTest` task runs a Gradle build in the project located
  * under the `tests` subdirectory.
  *
@@ -157,6 +194,10 @@ val integrationTest by tasks.registering(RunBuild::class) {
         it.tasks.findByName("test")?.let { testTask ->
             this@registering.dependsOn(testTask)
         }
+    }
+    doFirst {
+        materializeTestsLink("buildSrc")
+        materializeTestsLink("gradle.properties")
     }
 }
 

--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -43,11 +43,17 @@ import io.spine.gradle.kotlin.setFreeCompilerArgs
 import io.spine.gradle.repo.standardToSpineSdk
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
+/*
+ * The references below must stay fully qualified: Gradle compiles the extracted
+ * `buildscript` block separately from the rest of the script, without the
+ * file-level `import` statements. Short names fail here with
+ * "Unresolved reference" at script compilation time.
+ */
 @Suppress("RemoveRedundantQualifierName")
 buildscript {
     dependencies {
-        classpath(Protobuf.GradlePlugin.lib)
-        classpath(Kotlin.GradlePlugin.lib)
+        classpath(io.spine.dependency.lib.Protobuf.GradlePlugin.lib)
+        classpath(io.spine.dependency.lib.Kotlin.GradlePlugin.lib)
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes the CI failures on PR #66 — both the Ubuntu and Windows jobs fail in the
nested `tests` build run by `integrationTest`.

Two independent root causes:

### 1. Ubuntu + Windows: `Unresolved reference 'Protobuf'` / `'Kotlin'` (`tests/build.gradle.kts:49-50`)

Commit `e8fa227` (copilot-swe-agent) replaced the fully qualified names in the
`buildscript {}` block with imported short names. Gradle's Kotlin DSL compiles
the extracted `buildscript {}` block as a separate stage-1 program **without
the file-level `import` statements**, so the short names fail at script
compilation time on every platform. (Verified in isolation on Gradle 9.5.1:
short names fail, fully qualified names compile — which is why every other
`buildscript` block in the repo uses fully qualified names, and why this one
carries `@Suppress("RemoveRedundantQualifierName")`.)

**Fix:** restore the fully qualified references and document the constraint
next to the block.

### 2. Windows only: `Unresolved reference 'io'` (run 27230621848, before `e8fa227`)

The updated Windows workflow (via the recent `config` sync) sets
`git config --global core.symlinks false` before checkout. The
`tests/buildSrc -> ../buildSrc` symlink is then checked out as a plain text
file, so the nested build has no `buildSrc` at all and cannot resolve
`io.spine.dependency.*`.

**Fix (two layers):**
- Re-enable native symlinks on Windows CI (`core.symlinks true`). The
  symlinked layout had been green on Windows runners for ~3 years (the
  `tests/buildSrc` symlink dates back to Feb 2023; `.agents` links coexisted
  with green runs since Sep 2025), until this branch's `config` update flipped
  the setting.
- As a fallback, `integrationTest` now materializes `tests/buildSrc` and
  `tests/gradle.properties` as real copies when the symlinks were checked out
  as placeholder text files. This is a no-op on healthy checkouts and keeps
  the integration tests working even if a future `config` sync reintroduces
  `core.symlinks false`.

⚠️ `build-on-windows.yml` is distributed by the `config` repository — the
`core.symlinks` flip should be revisited upstream as well, or the next config
sync will reintroduce it (the materialization fallback covers that case).

## Verification

- Stage-1 import limitation and the FQN fix reproduced/verified in an isolated
  project on Gradle 9.5.1 (same wrapper version as CI).
- `materializeTestsLink` exercised with simulated placeholder files: replaces
  them with real copies (excluding `build/`, `.gradle/`), leaves healthy
  symlinks and already-materialized directories untouched (idempotent).
- A full local build is not possible in this sandbox (network policy blocks
  the Spine repositories), so the end-to-end confirmation is this PR's CI.

https://claude.ai/code/session_01R4SQvfE1a8n6cu6HP8ENoN

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4SQvfE1a8n6cu6HP8ENoN)_