### PR TITLE
Add `assertCompilationError` assertion to `testlib`

### DIFF
--- a/.agents/tasks/transfer-assert-compilation-error.md
+++ b/.agents/tasks/transfer-assert-compilation-error.md
@@ -1,0 +1,37 @@
+---
+slug: transfer-assert-compilation-error
+branch: claude/dazzling-rubin-g2qy8e
+owner: claude
+status: in-progress
+started: 2026-06-18
+---
+
+## Goal
+
+Make the `assertCompilationError` test assertion — introduced in
+`core-jvm-compiler` PR #101 (`:base` test fixtures) — a first-class part of the
+Spine Compiler `testlib` module, with tests. Then file an issue in
+`core-jvm-compiler` to migrate to the transferred function once the Compiler is
+released with it.
+
+## Context
+
+- Source: `core-jvm-compiler` `base/src/testFixtures/kotlin/io/spine/tools/core/jvm/Assertions.kt`.
+- Target package in `testlib`: `io.spine.testing.compiler`.
+- `testlib` already depends on `Logging.testLib` ("We need `tapConsole`.") and on
+  `:api` (which provides `io.spine.tools.compiler.Compilation`).
+- `AbstractCompilationErrorTest.assertCompilationFails` already duplicates the
+  `assertThrows<Compilation.Error>` + `tapConsole` pattern — fold it onto the new
+  shared function.
+
+## Plan
+- [ ] Add `Assertions.kt` with `public fun assertCompilationError(...)`.
+- [ ] Refactor `AbstractCompilationErrorTest.assertCompilationFails` to reuse it.
+- [ ] Add `AssertionsSpec.kt` covering: returns the error, captures console
+      output, fails when no error is thrown.
+- [ ] Bump version `2.0.0-SNAPSHOT.053` -> `.054` (separate commit).
+- [ ] Verify compile, push, open draft PR.
+- [ ] File migration issue in `core-jvm-compiler`.
+
+## Log
+- 2026-06-18 — drafted plan, executing.

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,5 +5,5 @@
 	path = .agents/shared
 	url = https://github.com/SpineEventEngine/agents.git
 	branch = master
-	update = checkout
+	update = merge
 	ignore = all

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Build on Ubuntu][ubuntu-badge]][ubuntu-build]
 [![Build on Windows][windows-badge]][windows-build]
 [![codecov.io][codecov-badge]][codecov-report]
-
 [![license][apache-badge]][apache-license]
 
 Spine Compiler is a collection of tools for generating quality

--- a/buildSrc/src/main/kotlin/BuildExtensions.kt
+++ b/buildSrc/src/main/kotlin/BuildExtensions.kt
@@ -337,7 +337,7 @@ val buildToolConfigurations: Array<String> = arrayOf(
 )
 
 /**
- * Make the `sourcesJar` task accept duplicated input which seems to occur
+ * Make the `sourcesJar` task accept duplicated input, which seems to occur
  * somewhere inside Protobuf Gradle Plugin.
  */
 fun Project.allowDuplicationInSourcesJar() {

--- a/buildSrc/src/main/kotlin/DokkaExts.kt
+++ b/buildSrc/src/main/kotlin/DokkaExts.kt
@@ -216,7 +216,7 @@ fun Project.htmlDocsJar(): TaskProvider<Jar> = tasks.getOrCreate("htmlDocsJar") 
 }
 
 /**
- * Tells if this task belongs to the execution graph which contains
+ * Tells if this task belongs to the execution graph that contains
  * the `publish` and `dokkaGenerate` tasks.
  *
  * This predicate could be useful for disabling publishing tasks

--- a/buildSrc/src/main/kotlin/LicenseSettings.kt
+++ b/buildSrc/src/main/kotlin/LicenseSettings.kt
@@ -1,31 +1,31 @@
 /*
-* Copyright 2025, TeamDev. All rights reserved.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* https://www.apache.org/licenses/LICENSE-2.0
-*
-* Redistribution and use in source and/or binary forms, with or without
-* modification, must retain the above copyright notice and the following
-* disclaimer.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-* A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-* OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-* SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-* LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-* DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-* THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
 /**
- * The settings of the software license which apply to the code of this project.
+ * The settings of the software license that apply to the code of this project.
  *
  * The constants defined in this object are used by the
  * [PublicationHandler][io.spine.gradle.publish.PublicationHandler] to set up

--- a/buildSrc/src/main/kotlin/Strings.kt
+++ b/buildSrc/src/main/kotlin/Strings.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@
  * This file provides extensions to `String` and `CharSequence` that wrap
  * analogues from standard Kotlin runtime.
  *
- * It helps in switching between versions of Gradle which have different versions of
+ * It helps in switching between versions of Gradle that have different versions of
  * the Kotlin runtime. Please see the bodies of the extension functions for details on
  * switching the implementations depending on the Kotlin version at hand.
  *

--- a/buildSrc/src/main/kotlin/io/spine/dependency/Dependency.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/Dependency.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ abstract class Dependency {
      *
      * @param project The project in which the artifacts are forced. Used for logging.
      * @param cfg The configuration for which the artifacts are forced.  Used for logging.
-     * @param rs The resolution strategy which forces the artifacts.
+     * @param rs The resolution strategy that forces the artifacts.
      */
     fun forceArtifacts(project: Project, cfg: Configuration, rs: ResolutionStrategy) {
         artifacts.values.forEach {
@@ -90,7 +90,7 @@ abstract class Dependency {
 }
 
 /**
- * A dependency which declares a Maven Bill of Materials (BOM).
+ * A dependency that declares a Maven Bill of Materials (BOM).
  *
  * @see <a href="https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#Bill_of_Materials_.28BOM.29_POMs">
  * Maven Bill of Materials</a>
@@ -110,7 +110,6 @@ abstract class DependencyWithBom : Dependency() {
  */
 fun Configuration.diagSuffix(project: Project): String =
     "the configuration `$name` in the project: `${project.path}`."
-
 
 private fun ResolutionStrategy.forceWithLogging(
     project: Project,

--- a/buildSrc/src/main/kotlin/io/spine/dependency/boms/BomsPlugin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/boms/BomsPlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
 
 /**
- * The plugin which forces versions of platforms declared in the [Boms] object.
+ * The plugin that forces versions of platforms declared in the [Boms] object.
  *
  * Versions are enforced via the
  * [org.gradle.api.artifacts.dsl.DependencyHandler.enforcedPlatform] call

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/CommonsCli.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/CommonsCli.kt
@@ -27,7 +27,7 @@
 package io.spine.dependency.lib
 
 /**
- * Commons CLI is a transitive dependency which we don't use directly.
+ * Commons CLI is a transitive dependency that we don't use directly.
  * We `force` it in [forceVersions].
  *
  * [Commons CLI](https://commons.apache.org/proper/commons-cli/)

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Kotlin.kt
@@ -35,7 +35,7 @@ import io.spine.dependency.DependencyWithBom
 object Kotlin : DependencyWithBom() {
 
     /**
-     * This is the version of Kotlin we use for writing code which does not
+     * This is the version of Kotlin we use for writing code that does not
      * depend on Gradle and the version of embedded Kotlin.
      */
     @Suppress("MemberVisibilityCanBePrivate") // used directly from the outside.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
@@ -33,8 +33,8 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName", "unused")
 object Base {
-    const val version = "2.0.0-SNAPSHOT.411"
-    const val versionForBuildScript = "2.0.0-SNAPSHOT.411"
+    const val version = "2.0.0-SNAPSHOT.413"
+    const val versionForBuildScript = "2.0.0-SNAPSHOT.413"
     const val group = Spine.group
     private const val prefix = "spine"
     const val libModule = "$prefix-base"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
@@ -72,7 +72,7 @@ object Compiler : Dependency() {
      * The version of the Compiler dependencies.
      */
     override val version: String
-    private const val fallbackVersion = "2.0.0-SNAPSHOT.052"
+    private const val fallbackVersion = "2.0.0-SNAPSHOT.053"
 
     /**
      * The distinct version of the Compiler used by other build tools.
@@ -81,7 +81,7 @@ object Compiler : Dependency() {
      * transitive dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "2.0.0-SNAPSHOT.052"
+    private const val fallbackDfVersion = "2.0.0-SNAPSHOT.053"
 
     /**
      * The artifact for the Compiler Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvm.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvm.kt
@@ -39,7 +39,7 @@ typealias CoreJava = CoreJvm
 @Suppress("ConstPropertyName", "unused")
 object CoreJvm {
     const val group = Spine.group
-    const val version = "2.0.0-SNAPSHOT.375"
+    const val version = "2.0.0-SNAPSHOT.376"
 
     const val coreArtifact = "spine-core"
     const val clientArtifact = "spine-client"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvmCompiler.kt
@@ -46,12 +46,12 @@ object CoreJvmCompiler {
     /**
      * The version used in the build classpath.
      */
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.073"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.077"
 
     /**
      * The version to be used for integration tests.
      */
-    const val version = "2.0.0-SNAPSHOT.073"
+    const val version = "2.0.0-SNAPSHOT.077"
 
     /**
      * The ID of the Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoTap.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoTap.kt
@@ -38,7 +38,7 @@ package io.spine.dependency.local
 )
 object ProtoTap {
     const val group = Spine.toolsGroup
-    const val version = "0.15.0"
+    const val version = "0.16.0"
     const val gradlePluginId = "io.spine.prototap"
     const val api = "$group:prototap-api:$version"
     const val gradlePlugin = "$group:prototap-gradle-plugin:$version"

--- a/buildSrc/src/main/kotlin/io/spine/gradle/Cli.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/Cli.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,11 +63,14 @@ class Cli(private val workingFolder: File) {
             redirectError(PIPE)
         }.start()
 
-        val exitCode = process.run {
-            inputStream!!.pourTo(outWriter)
-            errorStream!!.pourTo(errWriter)
-            waitFor()
-        }
+        val outReader = process.inputStream!!.pourTo(outWriter)
+        val errReader = process.errorStream!!.pourTo(errWriter)
+        val exitCode = process.waitFor()
+        // `waitFor()` returns on process exit but does not wait for the reader
+        // threads to finish draining the pipes; join them so the buffers hold
+        // the complete output before it is read below.
+        outReader.join()
+        errReader.join()
 
         if (exitCode == 0) {
             return outWriter.toString()
@@ -83,14 +86,14 @@ class Cli(private val workingFolder: File) {
 }
 
 /**
- * Asynchronously reads all lines from this [InputStream] and appends them
- * to the passed [StringWriter].
+ * Starts a background thread that reads all lines from this [InputStream] and
+ * appends them to [dest], returning the thread so the caller can [join][Thread.join]
+ * it once the process has exited, ensuring the buffer holds the complete output.
  */
-private fun InputStream.pourTo(dest: StringWriter) {
+private fun InputStream.pourTo(dest: StringWriter): Thread =
     Thread {
         val sc = Scanner(this)
         while (sc.hasNextLine()) {
             dest.append(sc.nextLine())
         }
-    }.start()
-}
+    }.also { it.start() }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/ConfigTester.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/ConfigTester.kt
@@ -250,7 +250,7 @@ class GitRepository(
 class ClonedRepo(
 
     /**
-     * Origin Git repository which is cloned.
+     * Origin Git repository that is cloned.
      */
     private val repo: GitRepository,
 
@@ -269,7 +269,7 @@ class ClonedRepo(
      * The original `buildSrc` folder, if it exists in this cloned repo, is renamed
      * to `buildSrc-original`.
      *
-     * Optionally, takes an [ignoredFolder] which will be excluded from the [source] paths
+     * Optionally, takes an [ignoredFolder] that will be excluded from the [source] paths
      * when copying.
      *
      *
@@ -289,7 +289,7 @@ class ClonedRepo(
      * The original `config` folder, if it exists in this cloned repo, is renamed
      * to `config-original`.
      *
-     * Optionally, takes an [ignoredFolder] which will be excluded from the [source] paths
+     * Optionally, takes an [ignoredFolder] that will be excluded from the [source] paths
      * when copying.
      *
      * Returns this instance of `ClonedRepo`, for call chaining.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/RunGradle.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/RunGradle.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.os.OperatingSystem
 
 /**
- * A Gradle task which runs another Gradle build.
+ * A Gradle task that runs another Gradle build.
  *
  * Launches Gradle wrapper under a given [directory] with the specified [taskNames] names.
  * The `clean` task is also run if current build includes a `clean` task.
@@ -56,7 +56,7 @@ open class RunGradle : DefaultTask() {
     }
 
     /**
-     * Path to the directory which contains a Gradle wrapper script.
+     * Path to the directory that contains a Gradle wrapper script.
      */
     @Internal
     lateinit var directory: String

--- a/buildSrc/src/main/kotlin/io/spine/gradle/dart/DartEnvironment.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/dart/DartEnvironment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ interface DartEnvironment {
     val projectName: String
 
     /**
-     * A directory which all artifacts are generated into.
+     * A directory that all artifacts are generated into.
      *
      * Default value: "$projectDir/build".
      */
@@ -73,7 +73,7 @@ interface DartEnvironment {
             .resolve(projectName)
 
     /**
-     * A directory which contains integration test Dart sources.
+     * A directory that contains integration test Dart sources.
      *
      * Default value: "$projectDir/integration-test".
      */

--- a/buildSrc/src/main/kotlin/io/spine/gradle/dart/DartExtension.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/dart/DartExtension.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ import org.gradle.kotlin.dsl.findByType
  * There are two ways to modify the environment:
  *
  *  1. Modify [DartEnvironment] interface directly. Go with this option when it is a global change
- *     that should affect all projects which use this extension.
+ *     that should affect all projects that use this extension.
  *  2. Use [DartExtension.environment] scope — for temporary and custom overridings.
  *
  * An example of a property overriding:
@@ -92,7 +92,7 @@ import org.gradle.kotlin.dsl.findByType
  * be named after a task it registers or a task group if several tasks are registered at once.
  * Then this extension is called in a project's `build.gradle.kts`.
  *
- * `DartTasks` and `DartPlugins` scopes extend [DartContext] which provides access
+ * `DartTasks` and `DartPlugins` scopes extend [DartContext] that provides access
  * to the current [DartEnvironment] and shortcuts for running `pub` tool.
  *
  * Below is the simplest example of how to create a primitive `printPubVersion` task.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/dart/task/IntegrationTest.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/dart/task/IntegrationTest.kt
@@ -41,7 +41,7 @@ private val integrationTestName = TaskName.of("integrationTest", Exec::class)
  *
  * The task runs integration tests of the `spine-dart` library against a sample
  * Spine-based application. The tests are run in Chrome browser because they use `WebFirebaseClient`
- * which only works in web environment.
+ * that only works in web environment.
  *
  * A sample Spine-based application is run from the `test-app` module before integration
  * tests start and is stopped as the tests complete.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/git/Repository.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/git/Repository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ import org.gradle.api.Project
  *   This configuration determines what ends up in the `author` and `committer` fields of a commit.
  * @property currentBranch The currently checked-out branch.
  */
+@Suppress("TooManyFunctions") // A cohesive wrapper over many small `git` commands.
 class Repository private constructor(
     private val project: Project,
     private val sshUrl: String,
@@ -86,12 +87,119 @@ class Repository private constructor(
      * Checks out the branch by its name.
      *
      * IMPORTANT. The branch must exist in the upstream repository.
+     * Use [checkoutOrCreate] to check out a branch that may not exist yet.
      */
     fun checkout(branch: String) {
         repoExecute("git", "checkout", branch)
         repoExecute("git", "pull")
 
         currentBranch = branch
+    }
+
+    /**
+     * Checks out the [branch], creating it in the remote repository if it does
+     * not exist yet.
+     *
+     * If the branch is already present on the remote, it is [checked out][checkout]
+     * as usual. Otherwise, it is created as an orphan branch seeded with
+     * [initialFiles] and pushed to the remote, so that subsequent commits with the
+     * documentation have a branch to append to.
+     *
+     * Creating the branch on the fly makes the very first documentation publication
+     * of a repository self-sufficient: the [documentation branch][Branch.documentation]
+     * no longer needs to be created manually beforehand.
+     *
+     * @param branch the name of the branch to check out or create.
+     * @param initialFiles the files — paths relative to the repository root mapped
+     *   to their content — to add to the initial commit when the branch is created.
+     *   Ignored when the branch already exists.
+     */
+    fun checkoutOrCreate(branch: String, initialFiles: Map<String, String> = emptyMap()) {
+        if (remoteHasBranch(branch)) {
+            // `remoteHasBranch` queries the remote directly via `git ls-remote`,
+            // which does not populate `refs/remotes/origin/*`. In a parallel
+            // build another module may have created the branch after this clone,
+            // so fetch first to make the `origin/$branch` ref available;
+            // otherwise `git checkout` cannot guess it and fails with a
+            // pathspec error.
+            repoExecute("git", "fetch", "origin")
+            checkout(branch)
+        } else {
+            createOrphanBranch(branch, initialFiles)
+        }
+    }
+
+    /**
+     * Tells whether the remote repository has a branch with the given [name].
+     *
+     * Queries the fully-qualified ref `refs/heads/$name` rather than the bare
+     * [name]: `git ls-remote` treats a bare name as a tail glob and would also
+     * match a namespaced branch such as `feature/$name`. Relies on `git ls-remote`
+     * returning an empty output with a zero exit code when the branch is absent,
+     * so the check does not raise an exception.
+     */
+    private fun remoteHasBranch(name: String): Boolean {
+        val output = repoExecute("git", "ls-remote", "--heads", "origin", "refs/heads/$name")
+        return output.isNotBlank()
+    }
+
+    /**
+     * Creates the [branch] as an orphan branch seeded with [initialFiles] and
+     * pushes it to the remote.
+     *
+     * `git switch --orphan` starts a new history with an empty working tree, so
+     * the source code of the default branch does not leak into the created branch.
+     * The [initialFiles] are written into this clean tree and staged before the
+     * initial commit, which stays `--allow-empty` to support seeding no files.
+     */
+    private fun createOrphanBranch(branch: String, initialFiles: Map<String, String>) {
+        repoExecute("git", "switch", "--orphan", branch)
+        initialFiles.forEach { (path, content) ->
+            location.toFile().resolve(path).writeText(content)
+            repoExecute("git", "add", path)
+        }
+        repoExecute(
+            "git",
+            "commit",
+            "--allow-empty",
+            "--message=Initialize the `$branch` branch."
+        )
+        currentBranch = branch
+        pushNewBranch(branch)
+    }
+
+    /**
+     * Pushes the just-created [branch] to the remote, setting up the upstream tracking.
+     *
+     * If the push is rejected because a concurrently running publication created
+     * the branch first (e.g., another module publishing documentation in the same
+     * parallel build), the remote branch is [adopted][adoptRemoteBranch] instead.
+     * Otherwise, the failure is genuine, and the original exception is rethrown.
+     */
+    private fun pushNewBranch(branch: String) {
+        try {
+            repoExecute("git", "push", "--set-upstream", "origin", branch)
+        } catch (e: IllegalStateException) {
+            // `Cli.execute` surfaces every non-zero `git` exit as an
+            // `IllegalStateException`, so this branch handles a rejected push.
+            // If the branch now exists on the remote, another module won the
+            // creation race and we adopt its branch; otherwise the failure is
+            // genuine and is rethrown.
+            repoExecute("git", "fetch", "origin")
+            if (!remoteHasBranch(branch)) {
+                throw e
+            }
+            adoptRemoteBranch(branch)
+        }
+    }
+
+    /**
+     * Discards the local orphan branch in favour of the same-named branch that
+     * already exists on the remote, keeping the local branch in sync with it.
+     */
+    private fun adoptRemoteBranch(branch: String) {
+        repoExecute("git", "reset", "--hard", "origin/$branch")
+        repoExecute("git", "branch", "--set-upstream-to=origin/$branch", branch)
     }
 
     /**
@@ -154,7 +262,8 @@ class Repository private constructor(
          * See [configureUser] documentation for more information.
          *
          * Performs checkout of the branch in case it was passed.
-         * By default, [master][Branch.master] is checked out.
+         * By default, [master][Branch.master] is checked out. A non-default branch
+         * that does not exist yet is created and seeded with [initialFiles].
          *
          * @throws IllegalArgumentException if SSH URL is an empty string.
          */
@@ -163,6 +272,7 @@ class Repository private constructor(
             sshUrl: String,
             user: UserInfo,
             branch: String = Branch.master,
+            initialFiles: Map<String, String> = emptyMap(),
         ): Repository {
             require(sshUrl.isNotBlank()) { "SSH URL cannot be an empty string." }
 
@@ -171,7 +281,7 @@ class Repository private constructor(
             repo.configureUser(user)
 
             if (branch != Branch.master) {
-                repo.checkout(branch)
+                repo.checkoutOrCreate(branch, initialFiles)
             }
 
             return repo

--- a/buildSrc/src/main/kotlin/io/spine/gradle/github/pages/RepositoryExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/github/pages/RepositoryExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,8 +38,10 @@ import org.gradle.api.Project
  *
  * The repository's GitHub SSH URL is derived from the `REPO_SLUG` environment
  * variable. The [branch][Branch.documentation] dedicated to publishing documentation
- * is automatically checked out in this repository. Also, the username and the email
- * of the git user are automatically configured.
+ * is automatically checked out in this repository, and created if it does not exist
+ * yet. A freshly created branch is seeded with a `CNAME` file so that GitHub Pages
+ * serves the documentation under the `spine.io` custom domain. Also, the username
+ * and the email of the git user are automatically configured.
  *
  * The username is set to `"UpdateGitHubPages Plugin"`, and the email is derived from
  * the `FORMAL_GIT_HUB_PAGES_AUTHOR` environment variable.
@@ -56,5 +58,10 @@ internal fun Repository.Factory.forPublishingDocumentation(project: Project): Re
 
     val branch = Branch.documentation
 
-    return clone(project, host, user, branch)
+    // When the `gh-pages` branch is created from scratch, seed it with a `CNAME`
+    // file so that GitHub Pages serves the documentation under the `spine.io`
+    // custom domain.
+    val initialFiles = mapOf("CNAME" to "spine.io\n")
+
+    return clone(project, host, user, branch, initialFiles)
 }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/github/pages/TaskName.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/github/pages/TaskName.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ package io.spine.gradle.github.pages
 object TaskName {
 
     /**
-     * The name of the task which updates the GitHub Pages.
+     * The name of the task that updates the GitHub Pages.
      */
     const val updateGitHubPages = "updateGitHubPages"
 

--- a/buildSrc/src/main/kotlin/io/spine/gradle/github/pages/UpdateGitHubPages.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/github/pages/UpdateGitHubPages.kt
@@ -42,7 +42,7 @@ import org.gradle.api.tasks.TaskContainer
 import org.gradle.api.tasks.TaskProvider
 
 /**
- * Registers the `updateGitHubPages` task which performs the update of
+ * Registers the `updateGitHubPages` task that performs the update of
  * the GitHub Pages with the documentation generated in Javadoc and HTML format
  * for a particular Gradle project.
  *
@@ -53,7 +53,7 @@ import org.gradle.api.tasks.TaskProvider
  * repository root. It is recommended to encrypt it in the repository and then decrypt
  * it on CI upon publication. Also, the script uses the `FORMAL_GIT_HUB_PAGES_AUTHOR`
  * environment variable to set the author email for the commits. The `gh-pages`
- * branch itself should exist before the plugin is run.
+ * branch is created automatically if it does not exist yet.
  *
  * NOTE: when changing the value of "FORMAL_GIT_HUB_PAGES_AUTHOR", one also must change
  * the SSH private (encrypted `deploy_key_rsa`) and the public
@@ -67,7 +67,7 @@ import org.gradle.api.tasks.TaskProvider
  *      REPO_SLUG: SpineEventEngine/base
  * ```
  *
- * @see UpdateGitHubPagesExtension for the extension which is used to configure
+ * @see UpdateGitHubPagesExtension for the extension that is used to configure
  *      this plugin
  */
 class UpdateGitHubPages : Plugin<Project> {
@@ -113,7 +113,7 @@ class UpdateGitHubPages : Plugin<Project> {
     }
 
     /**
-     * Registers `updateGitHubPages` task which performs no actual update, but prints
+     * Registers `updateGitHubPages` task that performs no actual update, but prints
      * the message telling the update is skipped, since the project is in
      * its `SNAPSHOT` version.
      */

--- a/buildSrc/src/main/kotlin/io/spine/gradle/java/Tasks.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/java/Tasks.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import org.gradle.kotlin.dsl.named
  *
  * Runs the unit tests using JUnit or TestNG.
  *
- * Depends on `testClasses`, and all tasks which produce the test runtime classpath.
+ * Depends on `testClasses`, and all tasks that produce the test runtime classpath.
  *
  * @see <a href="https://docs.gradle.org/current/userguide/java_plugin.html#sec:java_tasks">
  *     Tasks | The Java Plugin</a>

--- a/buildSrc/src/main/kotlin/io/spine/gradle/javadoc/ExcludeInternalDoclet.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/javadoc/ExcludeInternalDoclet.kt
@@ -36,7 +36,7 @@ import org.gradle.api.tasks.javadoc.Javadoc
 import org.gradle.external.javadoc.StandardJavadocDocletOptions
 
 /**
- * The doclet which removes Javadoc for `@Internal` things in the Java code.
+ * The doclet that removes Javadoc for `@Internal` things in the Java code.
  */
 @Suppress("ConstPropertyName")
 class ExcludeInternalDoclet {
@@ -57,7 +57,7 @@ class ExcludeInternalDoclet {
         const val className = "io.spine.tools.javadoc.ExcludeInternalDoclet"
 
         /**
-         * The name of the helper task which configures the Javadoc processing
+         * The name of the helper task that configures the Javadoc processing
          * to exclude `@Internal` types.
          */
         const val taskName = "noInternalJavadoc"
@@ -68,7 +68,7 @@ class ExcludeInternalDoclet {
     }
 
     /**
-     * Creates a custom Javadoc task for the [project] which excludes the types
+     * Creates a custom Javadoc task for the [project] that excludes the types
      * annotated as `@Internal`.
      *
      * The task is registered under [taskName].

--- a/buildSrc/src/main/kotlin/io/spine/gradle/javascript/JsEnvironment.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/javascript/JsEnvironment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ interface JsEnvironment {
         get() = projectDir.resolve("test")
 
     /**
-     * A directory which all artifacts are generated into.
+     * A directory that all artifacts are generated into.
      *
      * Default value: "$projectDir/build".
      */

--- a/buildSrc/src/main/kotlin/io/spine/gradle/javascript/JsExtension.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/javascript/JsExtension.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ import org.gradle.kotlin.dsl.findByType
  * There are two ways to modify the environment:
  *
  *  1. Update [JsEnvironment] directly. Go with this option when it is a global change
- *     that should affect all projects which use this extension.
+ *     that should affect all projects that use this extension.
  *  2. Use [JsExtension.environment] scope — for temporary and custom overridings.
  *
  * An example of a property overriding:
@@ -93,7 +93,7 @@ import org.gradle.kotlin.dsl.findByType
  * named after a task it registers or a task group if several tasks are registered at once.
  * Then this extension is called in a project's `build.gradle.kts`.
  *
- * `JsTasks` and `JsPlugins` scopes extend [JsContext] which provides access
+ * `JsTasks` and `JsPlugins` scopes extend [JsContext] that provides access
  * to the current [JsEnvironment] and shortcuts for running `npm` tool.
  *
  * Below is the simplest example of how to create a primitive `printNpmVersion` task.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/javascript/task/Assemble.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/javascript/task/Assemble.kt
@@ -142,7 +142,7 @@ private val installNodePackagesName = TaskName.of("installNodePackages")
 /**
  * Locates `installNodePackages` task in this [TaskContainer].
  *
- * The task installs Node packages which this module depends on using `npm install` command.
+ * The task installs Node packages that this module depends on using `npm install` command.
  *
  * The `npm install` command is executed with the vulnerability check disabled since
  * it cannot fail the task execution despite on vulnerabilities found.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/CheckVersionIncrement.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/CheckVersionIncrement.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 
 /**
- * A task which verifies that the current version of the library has not been published to the given
+ * A task that verifies that the current version of the library has not been published to the given
  * Maven repository yet.
  */
 open class CheckVersionIncrement : DefaultTask() {

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/CustomPublicationHandler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/CustomPublicationHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ import org.gradle.api.publish.maven.MavenPublication
  * which is <em>created</em> for a module. Instead, since the publications are already declared,
  * this class only [assigns Maven coordinates][copyProjectAttributes].
  *
- * A module which declares custom publications must be specified in
+ * A module that declares custom publications must be specified in
  * the [SpinePublishing.modulesWithCustomPublishing] property.
  *
  * If a module with [publications] declared locally is not specified as one with custom publishing,

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/GitHubPackages.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/GitHubPackages.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,12 +82,12 @@ private fun Project.readGitHubToken(): String {
 }
 
 /**
- * Read the personal access token for the `developers@spine.io` account which
- * has only the permission to read public GitHub packages.
+ * Reads the personal access token for the `developers@spine.io` account.
+ * The token grants only read access to public GitHub packages.
  *
  * The token is extracted from the archive called `aus.weis` stored under `buildSrc`.
  * The archive has such an unusual name to avoid scanning for tokens placed in repositories
- * which is performed by GitHub. Since we do not violate any security, it is OK to
+ * that is performed by GitHub. Since we do not violate any security, it is OK to
  * use such a workaround.
  */
 private fun Project.readTokenFromArchive(): String {

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/IncrementGuard.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/IncrementGuard.kt
@@ -33,7 +33,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 
 /**
- * Gradle plugin which adds a [CheckVersionIncrement] task.
+ * Gradle plugin that adds a [CheckVersionIncrement] task.
  *
  * The task is called `checkVersionIncrement` inserted before the `check` task.
  */
@@ -67,7 +67,7 @@ class IncrementGuard : Plugin<Project> {
      *  2. The job is a pull request targeting a default (`master` or `main`) or
      *     a release-line (e.g. `2.x-jdk8-master`) branch.
      *
-     * It is the responsibility of a branch which aims to merge into a default
+     * It is the responsibility of a branch that aims to merge into a default
      * (or otherwise protected) branch to bump the version. Auxiliary branches do not
      * deal with the versions in the release cycle, so pull requests targeting them,
      * direct pushes, and tag builds do not run the check. This also prevents unexpected

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/JarDsl.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/JarDsl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@
 package io.spine.gradle.publish
 
 /**
- * A DSL element of [SpinePublishing] extension which allows enabling publishing
+ * A DSL element of [SpinePublishing] extension that allows enabling publishing
  * of [testJar] artifact.
  *
  * This artifact contains compilation output of `test` source set. By default, it is not published.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/PublicationHandler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/PublicationHandler.kt
@@ -236,7 +236,7 @@ sealed class PublicationHandler(
          * If the handler for the given [project] was already created, the handler
          * gets new [destinations], [overwriting][publishTo] previously specified.
          *
-         * @return the handler for the given project which would handle publishing to
+         * @return the handler for the given project that would handle publishing to
          *  the specified [destinations].
          */
         fun serving(project: Project, destinations: Set<Repository>, vararg params: Any): H {

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/PublishingExts.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/PublishingExts.kt
@@ -318,7 +318,7 @@ internal fun TaskContainer.getOrCreate(name: String, init: Jar.() -> Unit): Task
  * Obtains as a set of [Jar] tasks, output of which is used as Maven artifacts.
  *
  * By default, only a jar with Java compilation output is included into publication. This method
- * registers tasks which produce additional artifacts according to the values of [jarFlags].
+ * registers tasks that produce additional artifacts according to the values of [jarFlags].
  *
  * @return the list of the registered tasks.
  */

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/SpinePublishing.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/SpinePublishing.kt
@@ -65,7 +65,7 @@ import org.gradle.kotlin.dsl.findByType
  * ### Filtering out test-only modules
  *
  * Sometimes a functional or an integration test requires a significant amount of
- * configuration code which is better understood when isolated into a separate module.
+ * configuration code that is better understood when isolated into a separate module.
  * Conventionally, we use the `-tests` suffix for naming such modules.
  *
  * In order to avoid publishing of such a test-only module, we use the following extensions

--- a/buildSrc/src/main/kotlin/io/spine/gradle/repo/Repository.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/repo/Repository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,12 +33,12 @@ import org.gradle.api.Project
 /**
  * A Maven repository.
  *
- * @param name The human-readable name which is also used in the publishing task names
+ * @param name The human-readable name that is also used in the publishing task names
  *   for identifying the target repository.
  *   The name must match the [regex].
  * @param releases The URL for publishing release versions of artifacts.
  * @param snapshots The URL for publishing [snapshot][io.spine.gradle.isSnapshot] versions.
- * @param credentialsFile The path to the file which contains the credentials for the registry.
+ * @param credentialsFile The path to the file that contains the credentials for the registry.
  * @param credentialValues The function to obtain an instance of [Credentials] from
  *   a Gradle [Project], if [credentialsFile] is not specified.
  */
@@ -116,7 +116,7 @@ data class Repository(
         val password = properties.getProperty("user.password")
         return Credentials(username, password)
     }
-    
+
     override fun equals(other: Any?): Boolean = when {
         this === other -> true
         other !is Repository -> false

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/license/LicenseReporter.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/license/LicenseReporter.kt
@@ -64,7 +64,7 @@ import org.gradle.kotlin.dsl.the
 object LicenseReporter {
 
     /**
-     * The name of the Gradle task which generates the reports for a specific Gradle project.
+     * The name of the Gradle task that generates the reports for a specific Gradle project.
      */
     private const val projectTaskName = "generateLicenseReport"
 
@@ -104,7 +104,7 @@ object LicenseReporter {
      *
      * The merge result is placed according to [Paths].
      *
-     * Registers a `mergeAllLicenseReports` which is specified to be executed after `build`.
+     * Registers a `mergeAllLicenseReports` that is specified to be executed after `build`.
      */
     fun mergeAllReports(project: Project) {
         val rootProject = project.rootProject

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/license/ModuleDataExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/license/ModuleDataExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,7 +92,7 @@ private fun MarkdownDocument.print(
 }
 
 /**
- * Prints the URL to the project which provides the dependency.
+ * Prints the URL to the project that provides the dependency.
  *
  * If the passed project URL is `null` or empty, it is not printed.
  */

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/license/Paths.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/license/Paths.kt
@@ -46,7 +46,7 @@ internal object Paths {
      * as the result of the [LicenseReporter] work.
      *
      * Its contents describe the licensing information for each of the Java dependencies
-     * which are referenced by Gradle projects in the repository.
+     * that are referenced by Gradle projects in the repository.
      */
     internal const val outputFilename = "dependencies.md"
 

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/DependencyWriter.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/DependencyWriter.kt
@@ -88,7 +88,12 @@ private constructor(
                     "dependency" {
                         "groupId" { xml.text(dependency.group) }
                         "artifactId" { xml.text(dependency.name) }
-                        "version" { xml.text(dependency.version) }
+                        // A BOM-managed dependency carries no explicit version.
+                        // Omit the element rather than emit `<version>null</version>`,
+                        // since `null` is not a valid Maven version.
+                        dependency.version?.let { version ->
+                            "version" { xml.text(version) }
+                        }
                         if (scopedDep.hasDefinedScope()) {
                             "scope" { xml.text(scopedDep.scopeName()) }
                         }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/testing/TestKitCoverage.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/testing/TestKitCoverage.kt
@@ -127,7 +127,7 @@ internal const val TESTKIT_COVERAGE_DIR: String = "jacoco-testkit"
 
 /**
  * The name of the system property carrying the absolute path to the JaCoCo
- * agent JAR which the test harness attaches to TestKit worker JVMs.
+ * agent JAR that the test harness attaches to TestKit worker JVMs.
  *
  * The value is read by `plugin-testlib` at test runtime.
  *

--- a/buildSrc/src/test/kotlin/io/spine/gradle/report/pom/DependencyWriterSpec.kt
+++ b/buildSrc/src/test/kotlin/io/spine/gradle/report/pom/DependencyWriterSpec.kt
@@ -256,6 +256,20 @@ internal class DependencyWriterSpec {
     }
 
     @Test
+    fun `omit the version of a dependency that declares none`() {
+        subproject("a-bom").declare("api", "io.grpc:grpc-stub")
+        subproject("b-lib").declare("api", SPINE_BASE)
+
+        val out = StringWriter()
+        DependencyWriter.of(rootProject).writeXmlTo(out)
+        val xml = out.toString()
+
+        xml shouldContain "<artifactId>grpc-stub</artifactId>"
+        xml shouldNotContain "<version>null</version>"
+        xml shouldContain "<version>2.0.0</version>"
+    }
+
+    @Test
     fun `write a production dependency as 'compile' even when it is also used in tests`() {
         subproject("a-tests").declare("testImplementation", SPINE_BASE)
         subproject("b-lib").declare("api", SPINE_BASE)

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1067,7 +1067,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 15 17:45:31 WEST 2026** using 
+This report was generated on **Thu Jun 18 02:38:05 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -1444,7 +1444,7 @@ This report was generated on **Mon Jun 15 17:45:31 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 15 17:45:30 WEST 2026** using 
+This report was generated on **Thu Jun 18 02:38:04 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -2522,7 +2522,7 @@ This report was generated on **Mon Jun 15 17:45:30 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 15 17:45:31 WEST 2026** using 
+This report was generated on **Thu Jun 18 02:38:05 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -3759,7 +3759,7 @@ This report was generated on **Mon Jun 15 17:45:31 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 15 17:45:31 WEST 2026** using 
+This report was generated on **Thu Jun 18 02:38:06 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -4783,7 +4783,7 @@ This report was generated on **Mon Jun 15 17:45:31 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 15 17:45:31 WEST 2026** using 
+This report was generated on **Thu Jun 18 02:38:05 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -5851,7 +5851,7 @@ This report was generated on **Mon Jun 15 17:45:31 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 15 17:45:31 WEST 2026** using 
+This report was generated on **Thu Jun 18 02:38:05 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -6946,7 +6946,7 @@ This report was generated on **Mon Jun 15 17:45:31 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 15 17:45:31 WEST 2026** using 
+This report was generated on **Thu Jun 18 02:38:05 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -8012,7 +8012,7 @@ This report was generated on **Mon Jun 15 17:45:31 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 15 17:45:31 WEST 2026** using 
+This report was generated on **Thu Jun 18 02:38:05 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -8852,7 +8852,7 @@ This report was generated on **Mon Jun 15 17:45:31 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 15 17:45:31 WEST 2026** using 
+This report was generated on **Thu Jun 18 02:38:05 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -9926,7 +9926,7 @@ This report was generated on **Mon Jun 15 17:45:31 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 15 17:45:31 WEST 2026** using 
+This report was generated on **Thu Jun 18 02:38:05 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -11107,6 +11107,6 @@ This report was generated on **Mon Jun 15 17:45:31 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 15 17:45:31 WEST 2026** using 
+This report was generated on **Thu Jun 18 02:38:05 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:compiler-api:2.0.0-SNAPSHOT.053`
+# Dependencies of `io.spine.tools:compiler-api:2.0.0-SNAPSHOT.054`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -1074,7 +1074,7 @@ This report was generated on **Mon Jun 15 17:45:31 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:compiler-api-tests:2.0.0-SNAPSHOT.053`
+# Dependencies of `io.spine.tools:compiler-api-tests:2.0.0-SNAPSHOT.054`
 
 ## Runtime
 ## Compile, tests, and tooling
@@ -1451,7 +1451,7 @@ This report was generated on **Mon Jun 15 17:45:30 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:compiler-backend:2.0.0-SNAPSHOT.053`
+# Dependencies of `io.spine.tools:compiler-backend:2.0.0-SNAPSHOT.054`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -2529,7 +2529,7 @@ This report was generated on **Mon Jun 15 17:45:31 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:compiler-cli:2.0.0-SNAPSHOT.053`
+# Dependencies of `io.spine.tools:compiler-cli:2.0.0-SNAPSHOT.054`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -3766,7 +3766,7 @@ This report was generated on **Mon Jun 15 17:45:31 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:compiler-gradle-api:2.0.0-SNAPSHOT.053`
+# Dependencies of `io.spine.tools:compiler-gradle-api:2.0.0-SNAPSHOT.054`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -4790,7 +4790,7 @@ This report was generated on **Mon Jun 15 17:45:31 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:compiler-gradle-plugin:2.0.0-SNAPSHOT.053`
+# Dependencies of `io.spine.tools:compiler-gradle-plugin:2.0.0-SNAPSHOT.054`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -5858,7 +5858,7 @@ This report was generated on **Mon Jun 15 17:45:31 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:compiler-jvm:2.0.0-SNAPSHOT.053`
+# Dependencies of `io.spine.tools:compiler-jvm:2.0.0-SNAPSHOT.054`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -6953,7 +6953,7 @@ This report was generated on **Mon Jun 15 17:45:31 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:compiler-params:2.0.0-SNAPSHOT.053`
+# Dependencies of `io.spine.tools:compiler-params:2.0.0-SNAPSHOT.054`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -8019,7 +8019,7 @@ This report was generated on **Mon Jun 15 17:45:31 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:compiler-protoc-plugin:2.0.0-SNAPSHOT.053`
+# Dependencies of `io.spine.tools:compiler-protoc-plugin:2.0.0-SNAPSHOT.054`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -8859,7 +8859,7 @@ This report was generated on **Mon Jun 15 17:45:31 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:compiler-test-env:2.0.0-SNAPSHOT.053`
+# Dependencies of `io.spine.tools:compiler-test-env:2.0.0-SNAPSHOT.054`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -9933,7 +9933,7 @@ This report was generated on **Mon Jun 15 17:45:31 WEST 2026** using
 
 
 
-# Dependencies of `io.spine.tools:compiler-testlib:2.0.0-SNAPSHOT.053`
+# Dependencies of `io.spine.tools:compiler-testlib:2.0.0-SNAPSHOT.054`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1067,7 +1067,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 02:38:05 WEST 2026** using 
+This report was generated on **Thu Jun 18 02:49:30 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -1444,7 +1444,7 @@ This report was generated on **Thu Jun 18 02:38:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 02:38:04 WEST 2026** using 
+This report was generated on **Thu Jun 18 02:49:29 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -2522,7 +2522,7 @@ This report was generated on **Thu Jun 18 02:38:04 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 02:38:05 WEST 2026** using 
+This report was generated on **Thu Jun 18 02:49:30 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -3759,7 +3759,7 @@ This report was generated on **Thu Jun 18 02:38:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 02:38:06 WEST 2026** using 
+This report was generated on **Thu Jun 18 02:49:30 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -4783,7 +4783,7 @@ This report was generated on **Thu Jun 18 02:38:06 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 02:38:05 WEST 2026** using 
+This report was generated on **Thu Jun 18 02:49:30 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -5851,7 +5851,7 @@ This report was generated on **Thu Jun 18 02:38:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 02:38:05 WEST 2026** using 
+This report was generated on **Thu Jun 18 02:49:30 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -6946,7 +6946,7 @@ This report was generated on **Thu Jun 18 02:38:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 02:38:05 WEST 2026** using 
+This report was generated on **Thu Jun 18 02:49:30 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -8012,7 +8012,7 @@ This report was generated on **Thu Jun 18 02:38:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 02:38:05 WEST 2026** using 
+This report was generated on **Thu Jun 18 02:49:30 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -8852,7 +8852,7 @@ This report was generated on **Thu Jun 18 02:38:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 02:38:05 WEST 2026** using 
+This report was generated on **Thu Jun 18 02:49:30 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -9926,7 +9926,7 @@ This report was generated on **Thu Jun 18 02:38:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 02:38:05 WEST 2026** using 
+This report was generated on **Thu Jun 18 02:49:30 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -11107,6 +11107,6 @@ This report was generated on **Thu Jun 18 02:38:05 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 02:38:05 WEST 2026** using 
+This report was generated on **Thu Jun 18 02:49:30 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>spine-compiler</artifactId>
-<version>2.0.0-SNAPSHOT.053</version>
+<version>2.0.0-SNAPSHOT.054</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -38,7 +38,6 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.fasterxml.jackson.dataformat</groupId>
     <artifactId>jackson-dataformat-yaml</artifactId>
-    <version>null</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -92,31 +91,29 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.grpc</groupId>
     <artifactId>grpc-protobuf</artifactId>
-    <version>null</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.grpc</groupId>
     <artifactId>grpc-stub</artifactId>
-    <version>null</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.411</version>
+    <version>2.0.0-SNAPSHOT.413</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-environment</artifactId>
-    <version>2.0.0-SNAPSHOT.411</version>
+    <version>2.0.0-SNAPSHOT.413</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-format</artifactId>
-    <version>2.0.0-SNAPSHOT.411</version>
+    <version>2.0.0-SNAPSHOT.413</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -140,7 +137,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-server</artifactId>
-    <version>2.0.0-SNAPSHOT.375</version>
+    <version>2.0.0-SNAPSHOT.376</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -200,7 +197,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>prototap-api</artifactId>
-    <version>0.15.0</version>
+    <version>0.16.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -212,7 +209,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>server-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.375</version>
+    <version>2.0.0-SNAPSHOT.376</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -350,7 +347,6 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>org.junit.platform</groupId>
     <artifactId>junit-platform-launcher</artifactId>
-    <version>null</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -381,22 +377,22 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>compiler-cli-all</artifactId>
-    <version>2.0.0-SNAPSHOT.052</version>
+    <version>2.0.0-SNAPSHOT.053</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>compiler-protoc-plugin</artifactId>
-    <version>2.0.0-SNAPSHOT.052</version>
+    <version>2.0.0-SNAPSHOT.053</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>core-jvm-plugins</artifactId>
-    <version>2.0.0-SNAPSHOT.073</version>
+    <version>2.0.0-SNAPSHOT.077</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>prototap-protoc-plugin</artifactId>
-    <version>0.15.0</version>
+    <version>0.16.0</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,8 +12,24 @@ org.gradle.parallel=true
 # so cold builds skip work whose inputs are unchanged.
 org.gradle.caching=true
 
-# Dokka plugin eats more memory than usual. Therefore, all builds should have enough.
-org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1024m -XX:+UseParallelGC -Dfile.encoding=UTF-8
+# Extra JVM args for the Gradle daemon, for two unrelated reasons:
+#
+# 1. The Dokka plugin eats more memory than usual, so all builds get a generous heap.
+# 2. The `--add-exports` / `--add-opens` flags expose the `jdk.compiler` internals that
+#    Error Prone needs on JDK 16+ (JEP 396). Passing them to the daemon here lets the
+#    `net.ltgt.errorprone` plugin run Error Prone in-process instead of forking a separate
+#    compiler JVM per task. See https://github.com/SpineEventEngine/config/issues/543
+org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1024m -XX:+UseParallelGC -Dfile.encoding=UTF-8 \
+  --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
 
 # suppress inspection "UnusedProperty"
 # The below property enables generation of XML reports for tests.

--- a/testlib/src/main/kotlin/io/spine/testing/compiler/AbstractCompilationErrorTest.kt
+++ b/testlib/src/main/kotlin/io/spine/testing/compiler/AbstractCompilationErrorTest.kt
@@ -27,14 +27,12 @@
 package io.spine.testing.compiler
 
 import com.google.protobuf.Descriptors.Descriptor
-import io.spine.logging.testing.tapConsole
 import io.spine.tools.compiler.Compilation
 import io.spine.tools.compiler.params.WorkingDirectory
 import io.spine.tools.compiler.plugin.Plugin
 import io.spine.tools.compiler.settings.SettingsDirectory
 import io.spine.tools.code.SourceSetName
 import java.nio.file.Path
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.io.TempDir
 
 /**
@@ -89,11 +87,10 @@ public abstract class AbstractCompilationErrorTest {
     public fun assertCompilationFails(descriptor: Descriptor): Compilation.Error {
         val setup = createSetup(descriptor)
         val pipeline = setup.createPipeline()
-        val error = assertThrows<Compilation.Error> {
-            // Redirect console output so that we don't print errors during the build.
-            tapConsole {
-                pipeline()
-            }
+        // `assertCompilationError` redirects console output so that we don't
+        // print errors during the build. Here we only need the thrown error.
+        val (error, _) = assertCompilationError {
+            pipeline()
         }
         return error
     }

--- a/testlib/src/main/kotlin/io/spine/testing/compiler/Assertions.kt
+++ b/testlib/src/main/kotlin/io/spine/testing/compiler/Assertions.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.testing.compiler
+
+import io.spine.logging.testing.tapConsole
+import io.spine.tools.compiler.Compilation
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * Asserts that the given [action] fails compilation, returning the thrown error
+ * together with the console output it produced.
+ *
+ * The console output is captured via [tapConsole] — so the deliberately provoked
+ * compilation error does not pollute the build log — and returned as the second
+ * component of the pair, letting callers inspect the diagnostics if they need to.
+ *
+ * @param action The code expected to fail with a [Compilation.Error].
+ * @return A pair of the thrown [Compilation.Error] and the captured console output.
+ * @see tapConsole
+ */
+public fun assertCompilationError(action: () -> Unit): Pair<Compilation.Error, String> {
+    lateinit var error: Compilation.Error
+    val output = tapConsole {
+        error = assertThrows<Compilation.Error> {
+            action()
+        }
+    }
+    return error to output
+}

--- a/testlib/src/test/kotlin/io/spine/testing/compiler/AssertionsSpec.kt
+++ b/testlib/src/test/kotlin/io/spine/testing/compiler/AssertionsSpec.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.testing.compiler
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.string.shouldContain
+import io.spine.tools.compiler.Compilation
+import java.io.File
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`assertCompilationError()` should")
+internal class AssertionsSpec {
+
+    private val file = File("Order.proto")
+    private val line = 100
+    private val column = 5
+    private val message = "The ID field has an unsupported type."
+
+    @Test
+    fun `return the thrown 'Compilation.Error'`() {
+        val (error, _) = assertCompilationError {
+            Compilation.error(file, line, column, message)
+        }
+        error.message shouldContain message
+    }
+
+    @Test
+    fun `capture the console output produced during compilation`() {
+        val (_, output) = assertCompilationError {
+            Compilation.error(file, line, column, message)
+        }
+        output shouldContain message
+        output shouldContain "$line:$column"
+    }
+
+    @Test
+    fun `fail when the action does not raise a compilation error`() {
+        shouldThrow<AssertionError> {
+            assertCompilationError {
+                // Does nothing, so no `Compilation.Error` is raised.
+            }
+        }
+    }
+}

--- a/testlib/src/test/kotlin/io/spine/testing/compiler/AssertionsSpec.kt
+++ b/testlib/src/test/kotlin/io/spine/testing/compiler/AssertionsSpec.kt
@@ -42,7 +42,7 @@ internal class AssertionsSpec {
     private val message = "The ID field has an unsupported type."
 
     @Test
-    fun `return the thrown 'Compilation.Error'`() {
+    fun `return the thrown compilation error`() {
         val (error, _) = assertCompilationError {
             Compilation.error(file, line, column, message)
         }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -30,7 +30,7 @@
  * This version is also used by integration test projects.
  * E.g. see `tests/consumer/build.gradle.kts`.
  */
-val compilerVersion: String by extra("2.0.0-SNAPSHOT.053")
+val compilerVersion: String by extra("2.0.0-SNAPSHOT.054")
 
 /**
  * The version, same as [compilerVersion], which is used for publishing


### PR DESCRIPTION
## What

Adds the `assertCompilationError` test assertion to the Spine Compiler `testlib`
module, in package `io.spine.testing.compiler`.

The function asserts that a given action fails compilation, returning the thrown
`Compilation.Error` together with the console output it produced. The output is
captured via `tapConsole` — so a deliberately provoked compilation error does not
pollute the build log — and returned as the second component of the pair, letting
callers inspect the diagnostics.

It originates from `core-jvm-compiler`
(SpineEventEngine/core-jvm-compiler#101, `:base` test fixtures). Hosting it in
`testlib` lets every Compiler consumer reuse it instead of redeclaring a local
copy.

## Changes

- **`testlib`**: new `Assertions.kt` with `public fun assertCompilationError(...)`.
- **`AbstractCompilationErrorTest.assertCompilationFails`** now delegates to the
  new function, removing the duplicated `assertThrows` +
  `tapConsole` pattern (behavior-preserving — the abstract base is published API,
  with no in-repo subclasses).
- **`AssertionsSpec`**: covers returning the error, capturing the console output,
  and failing when no compilation error is raised.
- Version bump `2.0.0-SNAPSHOT.053` → `2.0.0-SNAPSHOT.054`.

## Also in this branch

A routine `config` submodule sync (`798c1ef`) and the regenerated dependency
reports matching it (`c5edd7a`): `.gitmodules` (the `.agents/shared` update
strategy), shared `buildSrc` Gradle helpers, `gradle.properties`, and the
`pom.xml` / `dependencies.md` reports (transitive bumps such as `spine-base`
411→413, `spine-server` 375→376, `core-jvm-plugins` 073→077, `prototap`
0.15→0.16). These are `config`-distributed / generated files kept in sync and are
independent of the `testlib` change.

## Follow-up

Once the Compiler is released with this function, `core-jvm-compiler` should
migrate to it and drop its local copy. Tracked in
SpineEventEngine/core-jvm-compiler#102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017b7KWnPKYaMALDTEKtAjjc)_