### PR TITLE
Bump ToolBase to 2.0.0-SNAPSHOT.403 to fix descriptor-set build-cache bug

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
@@ -33,8 +33,8 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName", "unused")
 object Base {
-    const val version = "2.0.0-SNAPSHOT.421"
-    const val versionForBuildScript = "2.0.0-SNAPSHOT.421"
+    const val version = "2.0.0-SNAPSHOT.423"
+    const val versionForBuildScript = "2.0.0-SNAPSHOT.423"
     const val group = Spine.group
     private const val prefix = "spine"
     const val libModule = "$prefix-base"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Logging.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Logging.kt
@@ -33,7 +33,7 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName", "unused")
 object Logging {
-    const val version = "2.0.0-SNAPSHOT.419"
+    const val version = "2.0.0-SNAPSHOT.422"
     const val group = Spine.group
 
     const val loggingArtifact = "spine-logging"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -34,8 +34,8 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object ToolBase {
     const val group = Spine.toolsGroup
-    const val version = "2.0.0-SNAPSHOT.402"
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.402"
+    const val version = "2.0.0-SNAPSHOT.403"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.403"
 
     const val lib = "$group:tool-base:$version"
     const val classicCodegen = "$group:classic-codegen:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
@@ -36,7 +36,7 @@ object Validation {
     /**
      * The version of the Validation library artifacts.
      */
-    const val version = "2.0.0-SNAPSHOT.446"
+    const val version = "2.0.0-SNAPSHOT.449"
 
     const val group = Spine.toolsGroup
     private const val prefix = "validation"

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:compiler-api:2.0.0-SNAPSHOT.060`
+# Dependencies of `io.spine.tools:compiler-api:2.0.0-SNAPSHOT.061`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -1099,14 +1099,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 06 18:11:30 WEST 2026** using 
+This report was generated on **Tue Jul 07 17:24:16 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-api-tests:2.0.0-SNAPSHOT.060`
+# Dependencies of `io.spine.tools:compiler-api-tests:2.0.0-SNAPSHOT.061`
 
 ## Runtime
 ## Compile, tests, and tooling
@@ -1476,14 +1476,14 @@ This report was generated on **Mon Jul 06 18:11:30 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 06 18:11:29 WEST 2026** using 
+This report was generated on **Tue Jul 07 17:24:16 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-backend:2.0.0-SNAPSHOT.060`
+# Dependencies of `io.spine.tools:compiler-backend:2.0.0-SNAPSHOT.061`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -2586,14 +2586,14 @@ This report was generated on **Mon Jul 06 18:11:29 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 06 18:11:30 WEST 2026** using 
+This report was generated on **Tue Jul 07 17:24:16 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-cli:2.0.0-SNAPSHOT.060`
+# Dependencies of `io.spine.tools:compiler-cli:2.0.0-SNAPSHOT.061`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -3855,14 +3855,14 @@ This report was generated on **Mon Jul 06 18:11:30 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 06 18:11:30 WEST 2026** using 
+This report was generated on **Tue Jul 07 17:24:16 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-gradle-api:2.0.0-SNAPSHOT.060`
+# Dependencies of `io.spine.tools:compiler-gradle-api:2.0.0-SNAPSHOT.061`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -4879,14 +4879,14 @@ This report was generated on **Mon Jul 06 18:11:30 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 06 18:11:30 WEST 2026** using 
+This report was generated on **Tue Jul 07 17:24:16 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-gradle-plugin:2.0.0-SNAPSHOT.060`
+# Dependencies of `io.spine.tools:compiler-gradle-plugin:2.0.0-SNAPSHOT.061`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -5947,14 +5947,14 @@ This report was generated on **Mon Jul 06 18:11:30 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 06 18:11:30 WEST 2026** using 
+This report was generated on **Tue Jul 07 17:24:16 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-jvm:2.0.0-SNAPSHOT.060`
+# Dependencies of `io.spine.tools:compiler-jvm:2.0.0-SNAPSHOT.061`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -7074,14 +7074,14 @@ This report was generated on **Mon Jul 06 18:11:30 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 06 18:11:30 WEST 2026** using 
+This report was generated on **Tue Jul 07 17:24:16 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-params:2.0.0-SNAPSHOT.060`
+# Dependencies of `io.spine.tools:compiler-params:2.0.0-SNAPSHOT.061`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -8172,14 +8172,14 @@ This report was generated on **Mon Jul 06 18:11:30 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 06 18:11:30 WEST 2026** using 
+This report was generated on **Tue Jul 07 17:24:16 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-protoc-plugin:2.0.0-SNAPSHOT.060`
+# Dependencies of `io.spine.tools:compiler-protoc-plugin:2.0.0-SNAPSHOT.061`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -8249,11 +8249,11 @@ This report was generated on **Mon Jul 06 18:11:30 WEST 2026** using
      * **Project URL:** [https://github.com/Kotlin/kotlinx.coroutines](https://github.com/Kotlin/kotlinx.coroutines)
      * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-datetime. **Version** : 0.7.1.
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-datetime. **Version** : 0.8.0.
      * **Project URL:** [https://github.com/Kotlin/kotlinx-datetime](https://github.com/Kotlin/kotlinx-datetime)
      * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-datetime-jvm. **Version** : 0.7.1.
+1.  **Group** : org.jetbrains.kotlinx. **Name** : kotlinx-datetime-jvm. **Version** : 0.8.0.
      * **Project URL:** [https://github.com/Kotlin/kotlinx-datetime](https://github.com/Kotlin/kotlinx-datetime)
      * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -9012,14 +9012,14 @@ This report was generated on **Mon Jul 06 18:11:30 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 06 18:11:30 WEST 2026** using 
+This report was generated on **Tue Jul 07 17:24:16 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-test-env:2.0.0-SNAPSHOT.060`
+# Dependencies of `io.spine.tools:compiler-test-env:2.0.0-SNAPSHOT.061`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -10118,14 +10118,14 @@ This report was generated on **Mon Jul 06 18:11:30 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 06 18:11:30 WEST 2026** using 
+This report was generated on **Tue Jul 07 17:24:16 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-testlib:2.0.0-SNAPSHOT.060`
+# Dependencies of `io.spine.tools:compiler-testlib:2.0.0-SNAPSHOT.061`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -11331,6 +11331,6 @@ This report was generated on **Mon Jul 06 18:11:30 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jul 06 18:11:30 WEST 2026** using 
+This report was generated on **Tue Jul 07 17:24:16 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>compiler</artifactId>
-<version>2.0.0-SNAPSHOT.060</version>
+<version>2.0.0-SNAPSHOT.061</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -104,31 +104,31 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-base</artifactId>
-    <version>2.0.0-SNAPSHOT.421</version>
+    <version>2.0.0-SNAPSHOT.423</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-environment</artifactId>
-    <version>2.0.0-SNAPSHOT.421</version>
+    <version>2.0.0-SNAPSHOT.423</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-format</artifactId>
-    <version>2.0.0-SNAPSHOT.421</version>
+    <version>2.0.0-SNAPSHOT.423</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-logging</artifactId>
-    <version>2.0.0-SNAPSHOT.419</version>
+    <version>2.0.0-SNAPSHOT.422</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-logging-jvm</artifactId>
-    <version>2.0.0-SNAPSHOT.419</version>
+    <version>2.0.0-SNAPSHOT.422</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -158,7 +158,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-validation-jvm-runtime</artifactId>
-    <version>2.0.0-SNAPSHOT.446</version>
+    <version>2.0.0-SNAPSHOT.449</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -170,31 +170,31 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>gradle-plugin-api</artifactId>
-    <version>2.0.0-SNAPSHOT.402</version>
+    <version>2.0.0-SNAPSHOT.403</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>jvm-tools</artifactId>
-    <version>2.0.0-SNAPSHOT.402</version>
+    <version>2.0.0-SNAPSHOT.403</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>logging-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.419</version>
+    <version>2.0.0-SNAPSHOT.422</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>plugin-base</artifactId>
-    <version>2.0.0-SNAPSHOT.402</version>
+    <version>2.0.0-SNAPSHOT.403</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>protobuf-setup-plugins</artifactId>
-    <version>2.0.0-SNAPSHOT.402</version>
+    <version>2.0.0-SNAPSHOT.403</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -206,7 +206,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>psi-java</artifactId>
-    <version>2.0.0-SNAPSHOT.402</version>
+    <version>2.0.0-SNAPSHOT.403</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -218,7 +218,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>tool-base</artifactId>
-    <version>2.0.0-SNAPSHOT.402</version>
+    <version>2.0.0-SNAPSHOT.403</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -284,7 +284,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>plugin-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.402</version>
+    <version>2.0.0-SNAPSHOT.403</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -411,7 +411,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>validation-java-bundle</artifactId>
-    <version>2.0.0-SNAPSHOT.446</version>
+    <version>2.0.0-SNAPSHOT.449</version>
   </dependency>
   <dependency>
     <groupId>org.jacoco</groupId>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -30,7 +30,7 @@
  * This version is also used by integration test projects.
  * E.g. see `tests/consumer/build.gradle.kts`.
  */
-private val compilerVersion = "2.0.0-SNAPSHOT.060"
+private val compilerVersion = "2.0.0-SNAPSHOT.061"
 extra.set("compilerVersion", compilerVersion)
 
 /**


### PR DESCRIPTION
## What & why

`GenerateProtoTask` restored a stale, wrong-version `known_types` descriptor set from the shared Gradle build cache after a project **version bump**: the descriptor-set file name embeds the Maven version, but that name was **not** part of the task's cache key. Consumer builds then failed at test runtime with `io.spine.type.UnknownTypeException` for foundational types (e.g. `spine.core.CommandId`) — observed in core-jvm PR #1645 (version `.410 → .411`), 74 failures across `:core:test` and `:client:test`.

`DescriptorSetFilePlugin` is applied by the Compiler Gradle plugin and runs on the **plugin/buildscript classpath**, whose tool-base version is fixed by the **Compiler's own pin** — not by the consumer's project dependencies. So even a consumer already pinning tool-base `.403` still generated descriptors with the unfixed `.402` code the Compiler dragged in. The upstream fix (tool-base `502e3dfe`, *"Key the descriptor-set cache on the file name, not just the version"*, first shipped in `2.0.0-SNAPSHOT.403`) keys the cache on the descriptor-set file name; it reaches consumers only by advancing the Compiler's pin.

## Changes

- **ToolBase `.402 → .403`** (`version` + `dogfoodingVersion`) — the fix.
- Refresh other local Spine dependencies to their latest snapshots: **Base `.421 → .423`**, **Logging `.419 → .422`**, **Validation `.446 → .449`**.
- Bump `compilerVersion` `.060 → .061`.
- Regenerate `docs/dependencies/{dependencies.md,pom.xml}`; float the `config` submodule.

**`spine-time` held at `.242`:** bumping it to `.244` introduced a version skew (the `params` module resolves it transitively at `.242`), so it is left for a coordinated ecosystem move rather than forced.

## Verification

- `./gradlew build` is green; no `"uses several versions"` dependency-conflict warnings.
- Dependency reports regenerated to match.

## Downstream

Once a Compiler carrying tool-base `.403`+ is published, core-jvm bumps its Compiler pin and removes its temporary `workAroundDescriptorSetCacheBug()` (which disables `GenerateProtoTask` caching to unblock PR #1645).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
