### PR TITLE
Bump CoreJvm and exclude JetBrains Annotations from the published plugin graph

### DIFF
--- a/.agents/memory/MEMORY.md
+++ b/.agents/memory/MEMORY.md
@@ -6,6 +6,7 @@ See [README.md](README.md) for the format and routing rules.
 ## Feedback (validated patterns & corrections)
 
 - [copilot-review-request](feedback/copilot-review-request.md) — GraphQL `requestReviews` with `botIds: ["BOT_kgDOCnlnWA"]`; REST endpoint silently no-ops on re-requests.
+- [gradle-annotations-pin-exclusion](feedback/gradle-annotations-pin-exclusion.md) — publish plugins without `org.jetbrains:annotations`; never fix the `strictly 13.0` pin with consumer-side forces.
 
 ## Project (durable context & rationale)
 

--- a/.agents/memory/feedback/gradle-annotations-pin-exclusion.md
+++ b/.agents/memory/feedback/gradle-annotations-pin-exclusion.md
@@ -1,0 +1,38 @@
+---
+name: gradle-annotations-pin-exclusion
+description: Publish Gradle plugins without `org.jetbrains:annotations` — Gradle 9.6 pins it `strictly 13.0` on build script classpaths, and consumer-side `force(...)` is a band-aid that spreads.
+metadata:
+  type: feedback
+  since: 2026-07-24
+---
+
+Gradle 9.6 constrains `org.jetbrains:annotations` to `{strictly 13.0}`
+("Pinned to the embedded Kotlin") on build script classpaths carrying
+Kotlin-ecosystem plugins, while `kotlinx-coroutines` (via Aedile, gRPC
+Kotlin stubs, and the Kotlin Gradle plugin itself) requires `23.0.0`.
+Whether Gradle reconciles the two is **graph-shape sensitive**: an
+unrelated dependency bump (CoreJvm `.510 → .521`) flipped resolution
+from a clean `23.0.0 → 13.0` downgrade to a hard
+`Cannot find a version of 'org.jetbrains:annotations'` failure.
+
+**Why:** We repeatedly patched the symptom with
+`resolutionStrategy { force(JetBrainsAnnotations.lib) }` — root build,
+`tests/*`, twelve fixture templates — and every consumer of the plugin
+would have needed the same workaround. The producer-side fix removes the
+conflicting requirement from the published metadata once, for everyone:
+the annotations are compile-time metadata, and consumers still get
+`13.0` through the `kotlin-stdlib` edge, which satisfies the pin.
+
+**How to apply:** In every published Gradle plugin artifact, exclude
+`org.jetbrains:annotations` from all published dependencies (see
+`excludeJetBrainsAnnotations()` in `gradle-plugin/build.gradle.kts` and
+the Aedile exclusion in `api/build.gradle.kts`). Do not add new
+consumer-side `force(...)` workarounds for this module. To verify a fix
+or reproduce the failure, build a consumer-mirror probe: a scratch
+project applying `kotlin("jvm")` + the plugin from `mavenLocal()` with
+no forces — it fails or passes with the published metadata alone. The
+CoreJvm Compiler plugin still needs the same exclusion in its repo;
+until it ships, `tests/compiler-extension` keeps its force (comment in
+that file states the removal condition).
+
+Related: [[functional-test-fixtures]]

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@
 
 import io.spine.dependency.lib.Aedile
 import io.spine.dependency.lib.Jackson
+import io.spine.dependency.lib.JetBrainsAnnotations
 import io.spine.dependency.local.Base
 import io.spine.dependency.local.CoreJvm
 import io.spine.dependency.local.Logging
@@ -53,7 +54,16 @@ dependencies {
     api(Logging.lib)
 
     implementation(Reflect.lib)
-    implementation(Aedile.lib)
+    implementation(Aedile.lib) {
+        // Aedile brings `kotlinx-coroutines`, which requires
+        // `org.jetbrains:annotations:23.0.0`. Build script classpaths pin
+        // the module to the version of the Kotlin embedded into Gradle
+        // (`strictly 13.0`), and Gradle 9.6 may fail to reconcile the two
+        // declarations, making any artifact that transitively carries this
+        // requirement unresolvable as a build-time dependency.
+        // The annotations are compile-time metadata, not needed at run time.
+        exclude(group = JetBrainsAnnotations.groupId, module = JetBrainsAnnotations.artifactId)
+    }
 
     implementation(platform(Jackson.bom))
     with(Jackson) {

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -57,11 +57,12 @@ dependencies {
     implementation(Aedile.lib) {
         // Aedile brings `kotlinx-coroutines`, which requires
         // `org.jetbrains:annotations:23.0.0`. Build script classpaths pin
-        // the module to the version of the Kotlin embedded into Gradle
-        // (`strictly 13.0`), and Gradle 9.6 may fail to reconcile the two
-        // declarations, making any artifact that transitively carries this
-        // requirement unresolvable as a build-time dependency.
-        // The annotations are compile-time metadata, not needed at run time.
+        // the module to the version used by the Kotlin runtime embedded
+        // into Gradle (`strictly 13.0`), and Gradle 9.6 may fail to
+        // reconcile the two declarations, making any artifact that
+        // transitively carries this requirement unresolvable as
+        // a build-time dependency.
+        // The annotations are compile-time metadata, not needed at runtime.
         exclude(group = JetBrainsAnnotations.groupId, module = JetBrainsAnnotations.artifactId)
     }
 

--- a/api/src/main/kotlin/io/spine/tools/compiler/plugin/View.kt
+++ b/api/src/main/kotlin/io/spine/tools/compiler/plugin/View.kt
@@ -173,7 +173,4 @@ internal class DefaultViewRepository(
 
     override fun entityModelClass(): ProjectionClass<View<Any, ProjectionState<Any>, *>> =
         ProjectionClass.asProjectionClass(cls)
-
-    override fun logName(): String =
-        "${ViewRepository::class.simpleName}.default()"
 }

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -82,7 +82,7 @@ tasks.test {
 // (a coarse hang ceiling, not a performance budget). Intentionally NOT wired
 // into `check`/`build`; the `Engine performance smoke test` workflow runs it on
 // pull requests.
-val performanceTest by tasks.registering(Test::class) {
+tasks.register<Test>("performanceTest") {
     description = "Runs the engine performance smoke signal (timed `Pipeline` run, hang ceiling)."
     group = "verification"
     testClassesDirs = sourceSets.test.get().output.classesDirs

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvm.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvm.kt
@@ -39,7 +39,7 @@ typealias CoreJava = CoreJvm
 @Suppress("ConstPropertyName", "unused")
 object CoreJvm {
     const val group = Spine.group
-    const val version = "2.0.0-SNAPSHOT.511"
+    const val version = "2.0.0-SNAPSHOT.521"
 
     const val coreArtifact = "spine-core"
     const val clientArtifact = "spine-client"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvm.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvm.kt
@@ -39,7 +39,7 @@ typealias CoreJava = CoreJvm
 @Suppress("ConstPropertyName", "unused")
 object CoreJvm {
     const val group = Spine.group
-    const val version = "2.0.0-SNAPSHOT.510"
+    const val version = "2.0.0-SNAPSHOT.511"
 
     const val coreArtifact = "spine-core"
     const val clientArtifact = "spine-client"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvm.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvm.kt
@@ -39,7 +39,7 @@ typealias CoreJava = CoreJvm
 @Suppress("ConstPropertyName", "unused")
 object CoreJvm {
     const val group = Spine.group
-    const val version = "2.0.0-SNAPSHOT.521"
+    const val version = "2.0.0-SNAPSHOT.522"
 
     const val coreArtifact = "spine-core"
     const val clientArtifact = "spine-client"

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:compiler-api:2.0.0-SNAPSHOT.063`
+# Dependencies of `io.spine.tools:compiler-api:2.0.0-SNAPSHOT.064`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.1.
@@ -1102,14 +1102,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 23 18:33:50 WEST 2026** using 
+This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-api-tests:2.0.0-SNAPSHOT.063`
+# Dependencies of `io.spine.tools:compiler-api-tests:2.0.0-SNAPSHOT.064`
 
 ## Runtime
 ## Compile, tests, and tooling
@@ -1478,14 +1478,14 @@ This report was generated on **Thu Jul 23 18:33:50 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 23 18:33:50 WEST 2026** using 
+This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-backend:2.0.0-SNAPSHOT.063`
+# Dependencies of `io.spine.tools:compiler-backend:2.0.0-SNAPSHOT.064`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.1.
@@ -2591,14 +2591,14 @@ This report was generated on **Thu Jul 23 18:33:50 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 23 18:33:50 WEST 2026** using 
+This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-cli:2.0.0-SNAPSHOT.063`
+# Dependencies of `io.spine.tools:compiler-cli:2.0.0-SNAPSHOT.064`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.1.
@@ -3863,14 +3863,14 @@ This report was generated on **Thu Jul 23 18:33:50 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 23 18:33:50 WEST 2026** using 
+This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-gradle-api:2.0.0-SNAPSHOT.063`
+# Dependencies of `io.spine.tools:compiler-gradle-api:2.0.0-SNAPSHOT.064`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.1.
@@ -4890,14 +4890,14 @@ This report was generated on **Thu Jul 23 18:33:50 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 23 18:33:50 WEST 2026** using 
+This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-gradle-plugin:2.0.0-SNAPSHOT.063`
+# Dependencies of `io.spine.tools:compiler-gradle-plugin:2.0.0-SNAPSHOT.064`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.1.
@@ -5961,14 +5961,14 @@ This report was generated on **Thu Jul 23 18:33:50 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 23 18:33:50 WEST 2026** using 
+This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-jvm:2.0.0-SNAPSHOT.063`
+# Dependencies of `io.spine.tools:compiler-jvm:2.0.0-SNAPSHOT.064`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.1.
@@ -7091,14 +7091,14 @@ This report was generated on **Thu Jul 23 18:33:50 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 23 18:33:50 WEST 2026** using 
+This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-params:2.0.0-SNAPSHOT.063`
+# Dependencies of `io.spine.tools:compiler-params:2.0.0-SNAPSHOT.064`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.1.
@@ -8192,14 +8192,14 @@ This report was generated on **Thu Jul 23 18:33:50 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 23 18:33:50 WEST 2026** using 
+This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-protoc-plugin:2.0.0-SNAPSHOT.063`
+# Dependencies of `io.spine.tools:compiler-protoc-plugin:2.0.0-SNAPSHOT.064`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9035,14 +9035,14 @@ This report was generated on **Thu Jul 23 18:33:50 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 23 18:33:50 WEST 2026** using 
+This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-test-env:2.0.0-SNAPSHOT.063`
+# Dependencies of `io.spine.tools:compiler-test-env:2.0.0-SNAPSHOT.064`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.1.
@@ -10144,14 +10144,14 @@ This report was generated on **Thu Jul 23 18:33:50 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 23 18:33:50 WEST 2026** using 
+This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-testlib:2.0.0-SNAPSHOT.063`
+# Dependencies of `io.spine.tools:compiler-testlib:2.0.0-SNAPSHOT.064`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.1.
@@ -11360,6 +11360,6 @@ This report was generated on **Thu Jul 23 18:33:50 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 23 18:33:50 WEST 2026** using 
+This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1102,7 +1102,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using 
+This report was generated on **Fri Jul 24 18:42:23 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -1478,7 +1478,7 @@ This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using 
+This report was generated on **Fri Jul 24 18:42:21 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -2591,7 +2591,7 @@ This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using 
+This report was generated on **Fri Jul 24 18:42:23 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -3863,7 +3863,7 @@ This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using 
+This report was generated on **Fri Jul 24 18:42:23 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -4890,7 +4890,7 @@ This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using 
+This report was generated on **Fri Jul 24 18:42:23 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -5047,9 +5047,9 @@ This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using
      * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [MIT license](https://spdx.org/licenses/MIT.txt)
 
-1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 23.0.0.
-     * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
-     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 13.0.
+     * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-bom. **Version** : 2.3.21.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
@@ -5961,7 +5961,7 @@ This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using 
+This report was generated on **Fri Jul 24 18:42:23 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -7091,7 +7091,7 @@ This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using 
+This report was generated on **Fri Jul 24 18:42:23 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -8192,7 +8192,7 @@ This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using 
+This report was generated on **Fri Jul 24 18:42:23 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -9035,7 +9035,7 @@ This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using 
+This report was generated on **Fri Jul 24 18:42:23 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -10144,7 +10144,7 @@ This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using 
+This report was generated on **Fri Jul 24 18:42:23 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -11360,6 +11360,6 @@ This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 18:11:26 WEST 2026** using 
+This report was generated on **Fri Jul 24 18:42:23 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -140,7 +140,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-server</artifactId>
-    <version>2.0.0-SNAPSHOT.521</version>
+    <version>2.0.0-SNAPSHOT.522</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -212,7 +212,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>server-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.521</version>
+    <version>2.0.0-SNAPSHOT.522</version>
     <scope>compile</scope>
   </dependency>
   <dependency>

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>compiler</artifactId>
-<version>2.0.0-SNAPSHOT.063</version>
+<version>2.0.0-SNAPSHOT.064</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -122,13 +122,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-logging</artifactId>
-    <version>2.0.0-SNAPSHOT.422</version>
+    <version>2.0.0-SNAPSHOT.423</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-logging-jvm</artifactId>
-    <version>2.0.0-SNAPSHOT.422</version>
+    <version>2.0.0-SNAPSHOT.423</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -140,7 +140,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-server</artifactId>
-    <version>2.0.0-SNAPSHOT.510</version>
+    <version>2.0.0-SNAPSHOT.521</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -212,7 +212,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>server-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.510</version>
+    <version>2.0.0-SNAPSHOT.521</version>
     <scope>compile</scope>
   </dependency>
   <dependency>

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -24,6 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import io.spine.dependency.lib.JetBrainsAnnotations
 import io.spine.dependency.lib.Kotlin
 import io.spine.dependency.lib.Protobuf
 import io.spine.dependency.local.CoreJvm
@@ -101,24 +102,58 @@ testing {
     }
 }
 
+/**
+ * Excludes `org.jetbrains:annotations` from a published dependency of this plugin.
+ *
+ * Build script classpaths pin the module to the version used by the Kotlin
+ * runtime embedded into Gradle (`strictly 13.0`, "Pinned to the embedded
+ * Kotlin"), while `kotlinx-coroutines` and other transitive dependencies of
+ * this plugin require `23.0.0`. Gradle 9.6 may fail to reconcile the two
+ * declarations — the outcome depends on the shape of the consumer's dependency
+ * graph — making the plugin unresolvable without a consumer-side workaround,
+ * such as forcing the module version on the build script classpath.
+ *
+ * The annotations are compile-time metadata, not needed at run time.
+ * Consumers still receive version `13.0` through the `kotlin-stdlib`
+ * dependency, which satisfies the pin.
+ */
+fun ModuleDependency.excludeJetBrainsAnnotations() {
+    exclude(group = JetBrainsAnnotations.groupId, module = JetBrainsAnnotations.artifactId)
+}
+
 dependencies {
     compileOnly(gradleApi())
     compileOnly(gradleKotlinDsl())
     compileOnly(Protobuf.GradlePlugin.lib)
     compileOnly(Kotlin.GradlePlugin.api)
 
-    api(project(":gradle-api"))
-    api(ToolBase.gradlePluginApi)
+    api(project(":gradle-api")) {
+        excludeJetBrainsAnnotations()
+    }
+    api(ToolBase.gradlePluginApi) {
+        excludeJetBrainsAnnotations()
+    }
 
     implementation(project(":api")) {
         exclude(group = Spine.toolsGroup, module = ToolBase.psiJavaArtifactName)
         exclude(group = Spine.group, module = CoreJvm.serverArtifact)
+        excludeJetBrainsAnnotations()
     }
-    implementation(project(":params"))
-    implementation(ToolBase.lib)
-    implementation(ToolBase.jvmTools)
-    implementation(ToolBase.protobufSetupPlugins)
-    implementation(ToolBase.pluginBase)
+    implementation(project(":params")) {
+        excludeJetBrainsAnnotations()
+    }
+    implementation(ToolBase.lib) {
+        excludeJetBrainsAnnotations()
+    }
+    implementation(ToolBase.jvmTools) {
+        excludeJetBrainsAnnotations()
+    }
+    implementation(ToolBase.protobufSetupPlugins) {
+        excludeJetBrainsAnnotations()
+    }
+    implementation(ToolBase.pluginBase) {
+        excludeJetBrainsAnnotations()
+    }
 }
 
 /**

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -113,7 +113,7 @@ testing {
  * graph — making the plugin unresolvable without a consumer-side workaround,
  * such as forcing the module version on the build script classpath.
  *
- * The annotations are compile-time metadata, not needed at run time.
+ * The annotations are compile-time metadata, not needed at runtime.
  * Consumers still receive version `13.0` through the `kotlin-stdlib`
  * dependency, which satisfies the pin.
  */

--- a/gradle-plugin/src/functionalTest/kotlin/io/spine/tools/compiler/gradle/plugin/PluginSpec.kt
+++ b/gradle-plugin/src/functionalTest/kotlin/io/spine/tools/compiler/gradle/plugin/PluginSpec.kt
@@ -228,7 +228,7 @@ class PluginSpec {
     }
 
     @Test
-    @Disabled("https://github.com/SpineEventEngine/ProtoData/issues/88")
+    @Disabled("https://github.com/SpineEventEngine/compiler/issues/16")
     fun `add 'kotlin' built-in only' if 'java' plugin or Kotlin compile tasks are present`() {
         createProject("android-library")  // could be in native code
         launchAndExpectResult(SUCCESS)

--- a/gradle-plugin/src/functionalTest/resources/android-library/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/android-library/build.gradle.kts
@@ -24,18 +24,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import com.google.protobuf.gradle.protobuf
+import io.spine.dependency.lib.Grpc
 import io.spine.dependency.local.Base
+import io.spine.dependency.local.CoreJava
+import io.spine.dependency.local.Reflect
+import io.spine.dependency.local.TestLib
 import io.spine.gradle.repo.standardToSpineSdk
 
 buildscript {
     standardSpineSdkRepositories()
-    configurations.all {
-        resolutionStrategy {
-            force(
-                io.spine.dependency.lib.JetBrainsAnnotations.lib,
-            )
-        }
-    }
 }
 
 group = "io.spine.tools.test"

--- a/gradle-plugin/src/functionalTest/resources/android-library/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/android-library/build.gradle.kts
@@ -24,16 +24,18 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.protobuf
-import io.spine.dependency.lib.Grpc
 import io.spine.dependency.local.Base
-import io.spine.dependency.local.CoreJava
-import io.spine.dependency.local.Reflect
-import io.spine.dependency.local.TestLib
 import io.spine.gradle.repo.standardToSpineSdk
 
 buildscript {
     standardSpineSdkRepositories()
+    configurations.all {
+        resolutionStrategy {
+            force(
+                io.spine.dependency.lib.JetBrainsAnnotations.lib,
+            )
+        }
+    }
 }
 
 group = "io.spine.tools.test"

--- a/gradle-plugin/src/functionalTest/resources/android-library/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/android-library/build.gradle.kts
@@ -24,12 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.protobuf
-import io.spine.dependency.lib.Grpc
 import io.spine.dependency.local.Base
-import io.spine.dependency.local.CoreJava
-import io.spine.dependency.local.Reflect
-import io.spine.dependency.local.TestLib
 import io.spine.gradle.repo.standardToSpineSdk
 
 buildscript {

--- a/gradle-plugin/src/functionalTest/resources/cached-build-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/cached-build-test/build.gradle.kts
@@ -24,7 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.protobuf
 import io.spine.dependency.lib.Protobuf
 import io.spine.gradle.repo.standardToSpineSdk
 

--- a/gradle-plugin/src/functionalTest/resources/cached-build-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/cached-build-test/build.gradle.kts
@@ -24,12 +24,18 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.protobuf
 import io.spine.dependency.lib.Protobuf
 import io.spine.gradle.repo.standardToSpineSdk
 
 buildscript {
     standardSpineSdkRepositories()
+    configurations.all {
+        resolutionStrategy {
+            force(
+                io.spine.dependency.lib.JetBrainsAnnotations.lib,
+            )
+        }
+    }
 }
 
 group = "io.spine.tools.test"

--- a/gradle-plugin/src/functionalTest/resources/cached-build-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/cached-build-test/build.gradle.kts
@@ -24,18 +24,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import com.google.protobuf.gradle.protobuf
 import io.spine.dependency.lib.Protobuf
 import io.spine.gradle.repo.standardToSpineSdk
 
 buildscript {
     standardSpineSdkRepositories()
-    configurations.all {
-        resolutionStrategy {
-            force(
-                io.spine.dependency.lib.JetBrainsAnnotations.lib,
-            )
-        }
-    }
 }
 
 group = "io.spine.tools.test"

--- a/gradle-plugin/src/functionalTest/resources/copy-grpc/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/copy-grpc/build.gradle.kts
@@ -28,17 +28,9 @@ import com.google.protobuf.gradle.protobuf
 import com.google.protobuf.gradle.id
 import io.spine.gradle.repo.standardToSpineSdk
 import io.spine.dependency.lib.Protobuf
-import io.spine.gradle.repo.standardToSpineSdk
 
 buildscript {
     standardSpineSdkRepositories()
-    configurations.all {
-        resolutionStrategy {
-            force(
-                io.spine.dependency.lib.JetBrainsAnnotations.lib,
-            )
-        }
-    }
 }
 
 group = "io.spine.tools.test"

--- a/gradle-plugin/src/functionalTest/resources/copy-grpc/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/copy-grpc/build.gradle.kts
@@ -28,9 +28,17 @@ import com.google.protobuf.gradle.protobuf
 import com.google.protobuf.gradle.id
 import io.spine.gradle.repo.standardToSpineSdk
 import io.spine.dependency.lib.Protobuf
+import io.spine.gradle.repo.standardToSpineSdk
 
 buildscript {
     standardSpineSdkRepositories()
+    configurations.all {
+        resolutionStrategy {
+            force(
+                io.spine.dependency.lib.JetBrainsAnnotations.lib,
+            )
+        }
+    }
 }
 
 group = "io.spine.tools.test"

--- a/gradle-plugin/src/functionalTest/resources/coverage-agent-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/coverage-agent-test/build.gradle.kts
@@ -31,13 +31,6 @@ import org.gradle.process.CommandLineArgumentProvider
 
 buildscript {
     standardSpineSdkRepositories()
-    configurations.all {
-        resolutionStrategy {
-            force(
-                io.spine.dependency.lib.JetBrainsAnnotations.lib,
-            )
-        }
-    }
 }
 
 group = "io.spine.tools.test"

--- a/gradle-plugin/src/functionalTest/resources/coverage-agent-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/coverage-agent-test/build.gradle.kts
@@ -31,6 +31,13 @@ import org.gradle.process.CommandLineArgumentProvider
 
 buildscript {
     standardSpineSdkRepositories()
+    configurations.all {
+        resolutionStrategy {
+            force(
+                io.spine.dependency.lib.JetBrainsAnnotations.lib,
+            )
+        }
+    }
 }
 
 group = "io.spine.tools.test"

--- a/gradle-plugin/src/functionalTest/resources/coverage-agent-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/coverage-agent-test/build.gradle.kts
@@ -77,7 +77,7 @@ spine {
  * [LaunchSpineCompiler] task via the standard `JavaExec` fork options.
  * The agent writes a per-task `.exec` file under `build/jacoco-compiler/`.
  */
-val jacocoAgent: Configuration by configurations.creating
+val jacocoAgent: Configuration = configurations.create("jacocoAgent")
 
 dependencies {
     jacocoAgent("org.jacoco:org.jacoco.agent:${Jacoco.version}:runtime")

--- a/gradle-plugin/src/functionalTest/resources/empty-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/empty-test/build.gradle.kts
@@ -24,17 +24,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import com.google.protobuf.gradle.protobuf
 import io.spine.gradle.repo.standardToSpineSdk
 
 buildscript {
     standardSpineSdkRepositories()
-    configurations.all {
-        resolutionStrategy {
-            force(
-                io.spine.dependency.lib.JetBrainsAnnotations.lib,
-            )
-        }
-    }
 }
 
 group = "io.spine.tools.test"

--- a/gradle-plugin/src/functionalTest/resources/empty-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/empty-test/build.gradle.kts
@@ -24,7 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.protobuf
 import io.spine.gradle.repo.standardToSpineSdk
 
 buildscript {

--- a/gradle-plugin/src/functionalTest/resources/empty-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/empty-test/build.gradle.kts
@@ -24,11 +24,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.protobuf
 import io.spine.gradle.repo.standardToSpineSdk
 
 buildscript {
     standardSpineSdkRepositories()
+    configurations.all {
+        resolutionStrategy {
+            force(
+                io.spine.dependency.lib.JetBrainsAnnotations.lib,
+            )
+        }
+    }
 }
 
 group = "io.spine.tools.test"

--- a/gradle-plugin/src/functionalTest/resources/java-kotlin-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/java-kotlin-test/build.gradle.kts
@@ -24,7 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.protobuf
 import io.spine.dependency.lib.Protobuf
 import io.spine.gradle.repo.standardToSpineSdk
 

--- a/gradle-plugin/src/functionalTest/resources/java-kotlin-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/java-kotlin-test/build.gradle.kts
@@ -24,12 +24,18 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.protobuf
 import io.spine.dependency.lib.Protobuf
 import io.spine.gradle.repo.standardToSpineSdk
 
 buildscript {
     standardSpineSdkRepositories()
+    configurations.all {
+        resolutionStrategy {
+            force(
+                io.spine.dependency.lib.JetBrainsAnnotations.lib,
+            )
+        }
+    }
 }
 
 group = "io.spine.tools.test"

--- a/gradle-plugin/src/functionalTest/resources/java-kotlin-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/java-kotlin-test/build.gradle.kts
@@ -24,18 +24,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import com.google.protobuf.gradle.protobuf
 import io.spine.dependency.lib.Protobuf
 import io.spine.gradle.repo.standardToSpineSdk
 
 buildscript {
     standardSpineSdkRepositories()
-    configurations.all {
-        resolutionStrategy {
-            force(
-                io.spine.dependency.lib.JetBrainsAnnotations.lib,
-            )
-        }
-    }
 }
 
 group = "io.spine.tools.test"

--- a/gradle-plugin/src/functionalTest/resources/java-library-kotlin-jvm/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/java-library-kotlin-jvm/build.gradle.kts
@@ -24,7 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.protobuf
 import io.spine.dependency.lib.Protobuf
 import io.spine.gradle.repo.standardToSpineSdk
 

--- a/gradle-plugin/src/functionalTest/resources/java-library-kotlin-jvm/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/java-library-kotlin-jvm/build.gradle.kts
@@ -24,12 +24,18 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.protobuf
 import io.spine.dependency.lib.Protobuf
 import io.spine.gradle.repo.standardToSpineSdk
 
 buildscript {
     standardSpineSdkRepositories()
+    configurations.all {
+        resolutionStrategy {
+            force(
+                io.spine.dependency.lib.JetBrainsAnnotations.lib,
+            )
+        }
+    }
 }
 
 group = "io.spine.tools.test"

--- a/gradle-plugin/src/functionalTest/resources/java-library-kotlin-jvm/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/java-library-kotlin-jvm/build.gradle.kts
@@ -24,18 +24,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import com.google.protobuf.gradle.protobuf
 import io.spine.dependency.lib.Protobuf
 import io.spine.gradle.repo.standardToSpineSdk
 
 buildscript {
     standardSpineSdkRepositories()
-    configurations.all {
-        resolutionStrategy {
-            force(
-                io.spine.dependency.lib.JetBrainsAnnotations.lib,
-            )
-        }
-    }
 }
 
 group = "io.spine.tools.test"

--- a/gradle-plugin/src/functionalTest/resources/kotlin-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/kotlin-test/build.gradle.kts
@@ -24,7 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.protobuf
 import io.spine.dependency.lib.Protobuf
 import io.spine.gradle.repo.standardToSpineSdk
 

--- a/gradle-plugin/src/functionalTest/resources/kotlin-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/kotlin-test/build.gradle.kts
@@ -24,12 +24,18 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.protobuf
 import io.spine.dependency.lib.Protobuf
 import io.spine.gradle.repo.standardToSpineSdk
 
 buildscript {
     standardSpineSdkRepositories()
+    configurations.all {
+        resolutionStrategy {
+            force(
+                io.spine.dependency.lib.JetBrainsAnnotations.lib,
+            )
+        }
+    }
 }
 
 group = "io.spine.tools.test"

--- a/gradle-plugin/src/functionalTest/resources/kotlin-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/kotlin-test/build.gradle.kts
@@ -24,18 +24,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import com.google.protobuf.gradle.protobuf
 import io.spine.dependency.lib.Protobuf
 import io.spine.gradle.repo.standardToSpineSdk
 
 buildscript {
     standardSpineSdkRepositories()
-    configurations.all {
-        resolutionStrategy {
-            force(
-                io.spine.dependency.lib.JetBrainsAnnotations.lib,
-            )
-        }
-    }
 }
 
 group = "io.spine.tools.test"

--- a/gradle-plugin/src/functionalTest/resources/ksp-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/ksp-test/build.gradle.kts
@@ -24,7 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.protobuf
 import io.spine.dependency.lib.Protobuf
 import io.spine.gradle.repo.standardToSpineSdk
 

--- a/gradle-plugin/src/functionalTest/resources/ksp-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/ksp-test/build.gradle.kts
@@ -24,12 +24,18 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.protobuf
 import io.spine.dependency.lib.Protobuf
 import io.spine.gradle.repo.standardToSpineSdk
 
 buildscript {
     standardSpineSdkRepositories()
+    configurations.all {
+        resolutionStrategy {
+            force(
+                io.spine.dependency.lib.JetBrainsAnnotations.lib,
+            )
+        }
+    }
 }
 
 group = "io.spine.tools.test"

--- a/gradle-plugin/src/functionalTest/resources/ksp-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/ksp-test/build.gradle.kts
@@ -24,18 +24,12 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import com.google.protobuf.gradle.protobuf
 import io.spine.dependency.lib.Protobuf
 import io.spine.gradle.repo.standardToSpineSdk
 
 buildscript {
     standardSpineSdkRepositories()
-    configurations.all {
-        resolutionStrategy {
-            force(
-                io.spine.dependency.lib.JetBrainsAnnotations.lib,
-            )
-        }
-    }
 }
 
 group = "io.spine.tools.test"

--- a/gradle-plugin/src/functionalTest/resources/launch-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/launch-test/build.gradle.kts
@@ -24,17 +24,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import com.google.protobuf.gradle.protobuf
 import io.spine.gradle.repo.standardToSpineSdk
 
 buildscript {
     standardSpineSdkRepositories()
-    configurations.all {
-        resolutionStrategy {
-            force(
-                io.spine.dependency.lib.JetBrainsAnnotations.lib,
-            )
-        }
-    }
 }
 
 group = "io.spine.tools.test"

--- a/gradle-plugin/src/functionalTest/resources/launch-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/launch-test/build.gradle.kts
@@ -24,7 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.protobuf
 import io.spine.gradle.repo.standardToSpineSdk
 
 buildscript {

--- a/gradle-plugin/src/functionalTest/resources/launch-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/launch-test/build.gradle.kts
@@ -24,11 +24,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.protobuf
 import io.spine.gradle.repo.standardToSpineSdk
 
 buildscript {
     standardSpineSdkRepositories()
+    configurations.all {
+        resolutionStrategy {
+            force(
+                io.spine.dependency.lib.JetBrainsAnnotations.lib,
+            )
+        }
+    }
 }
 
 group = "io.spine.tools.test"

--- a/gradle-plugin/src/functionalTest/resources/test-source-set/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/test-source-set/build.gradle.kts
@@ -31,6 +31,13 @@ import org.gradle.api.tasks.SourceSetContainer
 
 buildscript {
     standardSpineSdkRepositories()
+    configurations.all {
+        resolutionStrategy {
+            force(
+                io.spine.dependency.lib.JetBrainsAnnotations.lib,
+            )
+        }
+    }
 }
 
 group = "io.spine.tools.test"

--- a/gradle-plugin/src/functionalTest/resources/test-source-set/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/test-source-set/build.gradle.kts
@@ -31,13 +31,6 @@ import org.gradle.api.tasks.SourceSetContainer
 
 buildscript {
     standardSpineSdkRepositories()
-    configurations.all {
-        resolutionStrategy {
-            force(
-                io.spine.dependency.lib.JetBrainsAnnotations.lib,
-            )
-        }
-    }
 }
 
 group = "io.spine.tools.test"

--- a/gradle-plugin/src/functionalTest/resources/with-functional-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/with-functional-test/build.gradle.kts
@@ -24,13 +24,19 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.protobuf
 import io.spine.dependency.lib.Protobuf
 import io.spine.gradle.repo.standardToSpineSdk
 import org.gradle.api.plugins.jvm.JvmTestSuite
 
 buildscript {
     standardSpineSdkRepositories()
+    configurations.all {
+        resolutionStrategy {
+            force(
+                io.spine.dependency.lib.JetBrainsAnnotations.lib,
+            )
+        }
+    }
 }
 
 group = "io.spine.tools.test"

--- a/gradle-plugin/src/functionalTest/resources/with-functional-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/with-functional-test/build.gradle.kts
@@ -24,19 +24,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import com.google.protobuf.gradle.protobuf
 import io.spine.dependency.lib.Protobuf
 import io.spine.gradle.repo.standardToSpineSdk
 import org.gradle.api.plugins.jvm.JvmTestSuite
 
 buildscript {
     standardSpineSdkRepositories()
-    configurations.all {
-        resolutionStrategy {
-            force(
-                io.spine.dependency.lib.JetBrainsAnnotations.lib,
-            )
-        }
-    }
 }
 
 group = "io.spine.tools.test"

--- a/gradle-plugin/src/functionalTest/resources/with-functional-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/with-functional-test/build.gradle.kts
@@ -24,7 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import com.google.protobuf.gradle.protobuf
 import io.spine.dependency.lib.Protobuf
 import io.spine.gradle.repo.standardToSpineSdk
 import org.gradle.api.plugins.jvm.JvmTestSuite

--- a/gradle-plugin/src/functionalTest/resources/with-functional-test/build.gradle.kts
+++ b/gradle-plugin/src/functionalTest/resources/with-functional-test/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,14 +69,8 @@ dependencies {
     Protobuf.libs.forEach { implementation(it) }
 }
 
-@Suppress("UNUSED_VARIABLE") /* `test` and `functionalTest` variables are really used by their
-  names and types for obtaining or creating corresponding suite instances via `by` calls. */
 testing {
     suites {
-        val test by getting(JvmTestSuite::class) {
-        }
-
-        val functionalTest by registering(JvmTestSuite::class) {
-        }
+        register<JvmTestSuite>("functionalTest")
     }
 }

--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -79,7 +79,7 @@ subprojects {
     }
     apply<BomsPlugin>()
 
-    val compilerVersion: String by extra
+    val compilerVersion = extra["compilerVersion"] as String
     group = "io.spine.compiler.tests"
     version = compilerVersion
 

--- a/tests/compiler-extension/build.gradle.kts
+++ b/tests/compiler-extension/build.gradle.kts
@@ -30,6 +30,12 @@ buildscript {
     standardSpineSdkRepositories()
     configurations.all {
         resolutionStrategy {
+            // The CoreJvm Compiler plugin on the classpath below still carries
+            // the `org.jetbrains:annotations:23.0.0` requirement, which clashes
+            // with the `strictly 13.0` pin Gradle puts on build script
+            // classpaths ("Pinned to the embedded Kotlin"). Remove this force
+            // once the CoreJvm Compiler excludes the module from its published
+            // dependencies the way the Spine Compiler Gradle plugin does.
             force(
                 io.spine.dependency.lib.JetBrainsAnnotations.lib,
             )

--- a/tests/compiler-extension/build.gradle.kts
+++ b/tests/compiler-extension/build.gradle.kts
@@ -24,7 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import io.spine.dependency.lib.AutoService
 import io.spine.dependency.local.ToolBase
 
 buildscript {
@@ -32,7 +31,7 @@ buildscript {
     configurations.all {
         resolutionStrategy {
             force(
-                io.spine.dependency.local.Logging.grpcContext,
+                io.spine.dependency.lib.JetBrainsAnnotations.lib,
             )
         }
     }

--- a/tests/compiler-extension/build.gradle.kts
+++ b/tests/compiler-extension/build.gradle.kts
@@ -33,9 +33,10 @@ buildscript {
             // The CoreJvm Compiler plugin on the classpath below still carries
             // the `org.jetbrains:annotations:23.0.0` requirement, which clashes
             // with the `strictly 13.0` pin Gradle puts on build script
-            // classpaths ("Pinned to the embedded Kotlin"). Remove this force
-            // once the CoreJvm Compiler excludes the module from its published
-            // dependencies the way the Spine Compiler Gradle plugin does.
+            // classpaths ("Pinned to the embedded Kotlin").
+            // TODO:2026-07-24:alexander.yevsyukov: Remove this force once the
+            //  CoreJvm Compiler excludes the module from its published
+            //  dependencies the way the Spine Compiler Gradle plugin does.
             //
             // The `Logging.grpcContext` force formerly kept here became
             // unnecessary with the CoreJvm `.521` bump: the integration tests

--- a/tests/compiler-extension/build.gradle.kts
+++ b/tests/compiler-extension/build.gradle.kts
@@ -36,6 +36,10 @@ buildscript {
             // classpaths ("Pinned to the embedded Kotlin"). Remove this force
             // once the CoreJvm Compiler excludes the module from its published
             // dependencies the way the Spine Compiler Gradle plugin does.
+            //
+            // The `Logging.grpcContext` force formerly kept here became
+            // unnecessary with the CoreJvm `.521` bump: the integration tests
+            // pass without it.
             force(
                 io.spine.dependency.lib.JetBrainsAnnotations.lib,
             )

--- a/tests/compiler-extension/build.gradle.kts
+++ b/tests/compiler-extension/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ buildscript {
     }
     apply(from = "$rootDir/../version.gradle.kts")
 
-    val compilerVersion: String by extra
+    val compilerVersion = extra["compilerVersion"] as String
     dependencies {
         classpath(spineCompiler.pluginLib(compilerVersion))
         classpath(coreJvmCompiler.pluginLib)
@@ -64,7 +64,7 @@ configurations.all {
     }
 }
 
-val compilerVersion: String by extra
+val compilerVersion = extra["compilerVersion"] as String
 
 dependencies {
     compileOnly("io.spine.tools:compiler-backend:$compilerVersion")

--- a/tests/consumer/build.gradle.kts
+++ b/tests/consumer/build.gradle.kts
@@ -39,6 +39,13 @@ buildscript {
     dependencies {
         classpath(spineCompiler.pluginLib(compilerVersion))
     }
+    configurations.all {
+        resolutionStrategy {
+            force(
+                io.spine.dependency.lib.JetBrainsAnnotations.lib,
+            )
+        }
+    }
 }
 
 apply(plugin = "io.spine.compiler")

--- a/tests/consumer/build.gradle.kts
+++ b/tests/consumer/build.gradle.kts
@@ -39,13 +39,6 @@ buildscript {
     dependencies {
         classpath(spineCompiler.pluginLib(compilerVersion))
     }
-    configurations.all {
-        resolutionStrategy {
-            force(
-                io.spine.dependency.lib.JetBrainsAnnotations.lib,
-            )
-        }
-    }
 }
 
 apply(plugin = "io.spine.compiler")

--- a/tests/consumer/build.gradle.kts
+++ b/tests/consumer/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ import io.spine.tools.gradle.root.rootExtension
 buildscript {
     standardSpineSdkRepositories()
     apply(from = "$rootDir/../version.gradle.kts")
-    val compilerVersion: String by extra
+    val compilerVersion = extra["compilerVersion"] as String
     dependencies {
         classpath(spineCompiler.pluginLib(compilerVersion))
     }

--- a/tests/in-place-consumer/build.gradle.kts
+++ b/tests/in-place-consumer/build.gradle.kts
@@ -28,6 +28,13 @@ import com.google.protobuf.gradle.protobuf
 
 buildscript {
     standardSpineSdkRepositories()
+    configurations.all {
+        resolutionStrategy {
+            force(
+                io.spine.dependency.lib.JetBrainsAnnotations.lib,
+            )
+        }
+    }
     apply(from = "$rootDir/../version.gradle.kts")
     val compilerVersion: String by extra
     dependencies {

--- a/tests/in-place-consumer/build.gradle.kts
+++ b/tests/in-place-consumer/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ buildscript {
         }
     }
     apply(from = "$rootDir/../version.gradle.kts")
-    val compilerVersion: String by extra
+    val compilerVersion = extra["compilerVersion"] as String
     dependencies {
         classpath(spineCompiler.pluginLib(compilerVersion))
     }

--- a/tests/in-place-consumer/build.gradle.kts
+++ b/tests/in-place-consumer/build.gradle.kts
@@ -28,13 +28,6 @@ import com.google.protobuf.gradle.protobuf
 
 buildscript {
     standardSpineSdkRepositories()
-    configurations.all {
-        resolutionStrategy {
-            force(
-                io.spine.dependency.lib.JetBrainsAnnotations.lib,
-            )
-        }
-    }
     apply(from = "$rootDir/../version.gradle.kts")
     val compilerVersion = extra["compilerVersion"] as String
     dependencies {

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -30,7 +30,7 @@
  * This version is also used by integration test projects.
  * E.g. see `tests/consumer/build.gradle.kts`.
  */
-private val compilerVersion = "2.0.0-SNAPSHOT.063"
+private val compilerVersion = "2.0.0-SNAPSHOT.064"
 extra.set("compilerVersion", compilerVersion)
 
 /**


### PR DESCRIPTION
Bumps CoreJvm to `2.0.0-SNAPSHOT.522` and makes the Compiler Gradle plugin resolvable on Gradle 9.6 build script classpaths without consumer-side workarounds.

## What changed

- **CoreJvm `2.0.0-SNAPSHOT.510` → `.522` (via `.511` and `.521`)**, adjusting `View.kt` for the upstream removal of `ViewRepository.logName()`.
- **JetBrains Annotations exclusion** — the root-cause fix of this PR. Gradle pins `org.jetbrains:annotations` to `{strictly 13.0}` on build script classpaths ("Pinned to the embedded Kotlin"), while `kotlinx-coroutines` (via Aedile and others) requires `23.0.0`. Whether Gradle 9.6 reconciles the two turned out to be dependency-graph-shape sensitive: the CoreJvm bump reshaped the graph enough to make the plugin unresolvable in consumer builds. The module is now excluded from the Aedile dependency of `:api` and from every published dependency of `:gradle-plugin` (documented helper `excludeJetBrainsAnnotations()`). The annotations are compile-time metadata; consumers still receive `13.0` through the `kotlin-stdlib` edge, which satisfies the pin.
- **Workaround cleanup** — the interim `force(JetBrainsAnnotations.lib)` additions are reverted in the functional-test fixture templates and removed from the `consumer` and `in-place-consumer` fixtures, so the integration tests now guard the exclusion against regressions. `compiler-extension` keeps its force — its classpath also holds the CoreJvm Compiler plugin, which still carries the requirement — with a `TODO:` stating the removal condition.
- **Gradle 9.6 deprecation fixes** — `tasks.register<Test>("performanceTest")` in `backend`, and `extra["compilerVersion"] as String` instead of the deprecated `by extra` delegate across the `tests/` build scripts.
- Team-memory entry documenting the diagnosis and the producer-side exclusion pattern.

## Verification

- `./gradlew build dokkaGenerate` green at HEAD, including `:gradle-plugin:functionalTest` (force-free fixtures) and `:integrationTest`.
- A consumer-mirror probe — `kotlin("jvm") 2.3.21` + `com.google.protobuf` + `id("io.spine.compiler")` resolved from Maven Local with no forces — fails against the `.063`-era metadata and passes with this branch's artifacts.
- Reviewers: `dependency-audit` and `kotlin-engineer` approved; `spine-code-review` and `review-docs` approved with changes, both addressed (`grpcContext` force drop documented; removal condition converted to Spine `TODO:` format).

## Notes for reviewers

- The CoreJvm `.522` artifacts (`spine-core`, `spine-client`, `spine-server`) currently exist in the developer's Maven Local; they must be available in the artifact registry before merging.
- Follow-ups outside this repo: the CoreJvm Compiler plugin needs the same annotations exclusion in its own repository, and the `excludeJetBrainsAnnotations()` helper is a candidate for hoisting into the shared `config` `buildSrc` once a second repository needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
