### PR TITLE
Update `config`

### DIFF
--- a/buildSrc/src/main/kotlin/BuildExtensions.kt
+++ b/buildSrc/src/main/kotlin/BuildExtensions.kt
@@ -30,6 +30,7 @@ import io.spine.dependency.build.ErrorProne
 import io.spine.dependency.build.GradleDoctor
 import io.spine.dependency.build.Ksp
 import io.spine.dependency.build.PluginPublishPlugin
+import io.spine.dependency.lib.JetBrainsAnnotations
 import io.spine.dependency.lib.Protobuf
 import io.spine.dependency.local.Compiler
 import io.spine.dependency.local.CoreJvmCompiler
@@ -39,10 +40,12 @@ import io.spine.dependency.test.Kover
 import io.spine.gradle.repo.standardToSpineSdk
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.tasks.JavaExec
 import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.ScriptHandlerScope
+import org.gradle.kotlin.dsl.exclude
 import org.gradle.plugin.use.PluginDependenciesSpec
 import org.gradle.plugin.use.PluginDependencySpec
 
@@ -346,4 +349,23 @@ fun Project.allowDuplicationInSourcesJar() {
             duplicatesStrategy = DuplicatesStrategy.INCLUDE
         }
     }
+}
+
+/**
+ * Excludes `org.jetbrains:annotations` from this published dependency.
+ *
+ * Build script classpaths pin the module to the version used by the Kotlin
+ * runtime embedded into Gradle (`strictly 13.0`, "Pinned to the embedded
+ * Kotlin"), while `kotlinx-coroutines` and other transitive dependencies of
+ * this plugin require `23.0.0`. Gradle 9.6 may fail to reconcile the two
+ * declarations — the outcome depends on the shape of the consumer's dependency
+ * graph — making the plugin unresolvable without a consumer-side workaround,
+ * such as forcing the module version on the build script classpath.
+ *
+ * The annotations are compile-time metadata, not needed at runtime.
+ * Consumers still receive version `13.0` through the `kotlin-stdlib`
+ * dependency, which satisfies the pin.
+ */
+fun ModuleDependency.excludeJetBrainsAnnotations() {
+    exclude(group = JetBrainsAnnotations.groupId, module = JetBrainsAnnotations.artifactId)
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Change.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Change.kt
@@ -33,7 +33,7 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName")
 object Change {
-    const val version = "2.0.0-SNAPSHOT.206"
+    const val version = "2.0.0-SNAPSHOT.207"
     const val group = Spine.group
     const val artifact = "spine-change"
     const val lib = "$group:$artifact:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
@@ -72,7 +72,7 @@ object Compiler : Dependency() {
      * The version of the Compiler dependencies.
      */
     override val version: String
-    private const val fallbackVersion = "2.0.0-SNAPSHOT.062"
+    private const val fallbackVersion = "2.0.0-SNAPSHOT.064"
 
     /**
      * The distinct version of the Compiler used by other build tools.
@@ -81,7 +81,7 @@ object Compiler : Dependency() {
      * transitive dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "2.0.0-SNAPSHOT.062"
+    private const val fallbackDfVersion = "2.0.0-SNAPSHOT.064"
 
     /**
      * The artifact for the Compiler Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Logging.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Logging.kt
@@ -33,7 +33,7 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName", "unused")
 object Logging {
-    const val version = "2.0.0-SNAPSHOT.422"
+    const val version = "2.0.0-SNAPSHOT.423"
     const val group = Spine.group
 
     const val loggingArtifact = "spine-logging"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Time.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Time.kt
@@ -40,7 +40,7 @@ import io.spine.dependency.Dependency
 )
 object Time : Dependency() {
     override val group = Spine.group
-    override val version = "2.0.0-SNAPSHOT.244"
+    override val version = "2.0.0-SNAPSHOT.250"
     private const val infix = "spine-time"
 
     fun lib(version: String): String = "$group:$infix:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
@@ -36,7 +36,7 @@ object Validation {
     /**
      * The version of the Validation library artifacts.
      */
-    const val version = "2.0.0-SNAPSHOT.450"
+    const val version = "2.0.0-SNAPSHOT.460"
 
     const val group = Spine.toolsGroup
     private const val prefix = "validation"

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine.tools:compiler-api:2.0.0-SNAPSHOT.064`
+# Dependencies of `io.spine.tools:compiler-api:2.0.0-SNAPSHOT.065`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.1.
@@ -1102,14 +1102,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 18:42:23 WEST 2026** using 
+This report was generated on **Mon Aug 03 17:17:20 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-api-tests:2.0.0-SNAPSHOT.064`
+# Dependencies of `io.spine.tools:compiler-api-tests:2.0.0-SNAPSHOT.065`
 
 ## Runtime
 ## Compile, tests, and tooling
@@ -1478,14 +1478,14 @@ This report was generated on **Fri Jul 24 18:42:23 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 18:42:21 WEST 2026** using 
+This report was generated on **Mon Aug 03 17:17:19 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-backend:2.0.0-SNAPSHOT.064`
+# Dependencies of `io.spine.tools:compiler-backend:2.0.0-SNAPSHOT.065`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.1.
@@ -2591,14 +2591,14 @@ This report was generated on **Fri Jul 24 18:42:21 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 18:42:23 WEST 2026** using 
+This report was generated on **Mon Aug 03 17:17:20 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-cli:2.0.0-SNAPSHOT.064`
+# Dependencies of `io.spine.tools:compiler-cli:2.0.0-SNAPSHOT.065`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.1.
@@ -3863,14 +3863,14 @@ This report was generated on **Fri Jul 24 18:42:23 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 18:42:23 WEST 2026** using 
+This report was generated on **Mon Aug 03 17:17:20 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-gradle-api:2.0.0-SNAPSHOT.064`
+# Dependencies of `io.spine.tools:compiler-gradle-api:2.0.0-SNAPSHOT.065`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.1.
@@ -4890,14 +4890,14 @@ This report was generated on **Fri Jul 24 18:42:23 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 18:42:23 WEST 2026** using 
+This report was generated on **Mon Aug 03 17:17:20 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-gradle-plugin:2.0.0-SNAPSHOT.064`
+# Dependencies of `io.spine.tools:compiler-gradle-plugin:2.0.0-SNAPSHOT.065`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.1.
@@ -5961,14 +5961,14 @@ This report was generated on **Fri Jul 24 18:42:23 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 18:42:23 WEST 2026** using 
+This report was generated on **Mon Aug 03 17:17:20 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-jvm:2.0.0-SNAPSHOT.064`
+# Dependencies of `io.spine.tools:compiler-jvm:2.0.0-SNAPSHOT.065`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.1.
@@ -7091,14 +7091,14 @@ This report was generated on **Fri Jul 24 18:42:23 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 18:42:23 WEST 2026** using 
+This report was generated on **Mon Aug 03 17:17:20 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-params:2.0.0-SNAPSHOT.064`
+# Dependencies of `io.spine.tools:compiler-params:2.0.0-SNAPSHOT.065`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.1.
@@ -8192,14 +8192,14 @@ This report was generated on **Fri Jul 24 18:42:23 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 18:42:23 WEST 2026** using 
+This report was generated on **Mon Aug 03 17:17:20 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-protoc-plugin:2.0.0-SNAPSHOT.064`
+# Dependencies of `io.spine.tools:compiler-protoc-plugin:2.0.0-SNAPSHOT.065`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -9035,14 +9035,14 @@ This report was generated on **Fri Jul 24 18:42:23 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 18:42:23 WEST 2026** using 
+This report was generated on **Mon Aug 03 17:17:20 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-test-env:2.0.0-SNAPSHOT.064`
+# Dependencies of `io.spine.tools:compiler-test-env:2.0.0-SNAPSHOT.065`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.1.
@@ -10144,14 +10144,14 @@ This report was generated on **Fri Jul 24 18:42:23 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 18:42:23 WEST 2026** using 
+This report was generated on **Mon Aug 03 17:17:20 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:compiler-testlib:2.0.0-SNAPSHOT.064`
+# Dependencies of `io.spine.tools:compiler-testlib:2.0.0-SNAPSHOT.065`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.1.
@@ -11360,6 +11360,6 @@ This report was generated on **Fri Jul 24 18:42:23 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Jul 24 18:42:23 WEST 2026** using 
+This report was generated on **Mon Aug 03 17:17:20 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine.tools</groupId>
 <artifactId>compiler</artifactId>
-<version>2.0.0-SNAPSHOT.064</version>
+<version>2.0.0-SNAPSHOT.065</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -146,19 +146,19 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-time</artifactId>
-    <version>2.0.0-SNAPSHOT.244</version>
+    <version>2.0.0-SNAPSHOT.250</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-time-java</artifactId>
-    <version>2.0.0-SNAPSHOT.244</version>
+    <version>2.0.0-SNAPSHOT.250</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-validation-jvm-runtime</artifactId>
-    <version>2.0.0-SNAPSHOT.450</version>
+    <version>2.0.0-SNAPSHOT.460</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -182,7 +182,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>logging-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.422</version>
+    <version>2.0.0-SNAPSHOT.423</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -290,7 +290,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>time-testlib</artifactId>
-    <version>2.0.0-SNAPSHOT.244</version>
+    <version>2.0.0-SNAPSHOT.250</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -381,12 +381,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>compiler-cli-all</artifactId>
-    <version>2.0.0-SNAPSHOT.062</version>
+    <version>2.0.0-SNAPSHOT.064</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>compiler-protoc-plugin</artifactId>
-    <version>2.0.0-SNAPSHOT.062</version>
+    <version>2.0.0-SNAPSHOT.064</version>
   </dependency>
   <dependency>
     <groupId>io.spine.tools</groupId>
@@ -411,7 +411,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>validation-java-bundle</artifactId>
-    <version>2.0.0-SNAPSHOT.450</version>
+    <version>2.0.0-SNAPSHOT.460</version>
   </dependency>
   <dependency>
     <groupId>org.jacoco</groupId>

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -24,7 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import io.spine.dependency.lib.JetBrainsAnnotations
 import io.spine.dependency.lib.Kotlin
 import io.spine.dependency.lib.Protobuf
 import io.spine.dependency.local.CoreJvm
@@ -100,25 +99,6 @@ testing {
             }
         }
     }
-}
-
-/**
- * Excludes `org.jetbrains:annotations` from a published dependency of this plugin.
- *
- * Build script classpaths pin the module to the version used by the Kotlin
- * runtime embedded into Gradle (`strictly 13.0`, "Pinned to the embedded
- * Kotlin"), while `kotlinx-coroutines` and other transitive dependencies of
- * this plugin require `23.0.0`. Gradle 9.6 may fail to reconcile the two
- * declarations — the outcome depends on the shape of the consumer's dependency
- * graph — making the plugin unresolvable without a consumer-side workaround,
- * such as forcing the module version on the build script classpath.
- *
- * The annotations are compile-time metadata, not needed at runtime.
- * Consumers still receive version `13.0` through the `kotlin-stdlib`
- * dependency, which satisfies the pin.
- */
-fun ModuleDependency.excludeJetBrainsAnnotations() {
-    exclude(group = JetBrainsAnnotations.groupId, module = JetBrainsAnnotations.artifactId)
 }
 
 dependencies {

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -203,10 +203,6 @@ tasks {
     check {
         dependsOn(testing.suites.named("functionalTest"))
     }
-
-    publishPlugins {
-        notCompatibleWithConfigurationCache("https://github.com/gradle/gradle/issues/21283")
-    }
 }
 
 /**

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -30,7 +30,7 @@
  * This version is also used by integration test projects.
  * E.g. see `tests/consumer/build.gradle.kts`.
  */
-private val compilerVersion = "2.0.0-SNAPSHOT.064"
+private val compilerVersion = "2.0.0-SNAPSHOT.065"
 extra.set("compilerVersion", compilerVersion)
 
 /**


### PR DESCRIPTION
This PR pulls the latest config, migrating to the `excludeJetBrainsAnnotations()` extension provided by the latest version.

Local dependencies were also updated via the `config`.